### PR TITLE
Use https url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "buildroot"]
 	path = buildroot
-	url = git@github.com:open-power/buildroot.git
+	url = https://github.com/open-power/buildroot


### PR DESCRIPTION
If we use the ssh transport, the user must have a vaild ssh key
configured for github (irrespective of write access to the repo).

Instead use https, which does not require login and should be the most
commonly available transport.

Signed-off-by: Joel Stanley joel@jms.id.au
