### PR TITLE
README: Use distro packages, not CPAN

### DIFF
--- a/README
+++ b/README
@@ -10,9 +10,7 @@ Building on *64-bit* Ubuntu/Debian systems
 1. Install Ubuntu 14.04 or Debian 7.5 64-bit.
 2. Install the packages necessary for the build:
 > sudo apt-get install cscope ctags libz-dev libexpat-dev libc6-dev-i386 gcc g++ git bison flex gcc-multilib g++-multilib libxml-simple-perl libxml-sax-perl
-3. Override the /bin/dash default shell configuration, you want to answer "no":
-> sudo dpkg-reconfigure dash
-4. Continue with the clone, environment setup, and build as noted above.
+3. Continue with the clone, environment setup, and build as noted above.
 
 Building on *64-bit* Fedora systems
 ==========================================


### PR DESCRIPTION
The XML::Simple and XML::SAX::Expat perl libraries are available as
Debian/Ubuntu packages.

Signed-off-by: Jeremy Kerr jk@ozlabs.org
