### PR TITLE
Fixes for building on Ubuntu 14.10

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,9 @@ Building on *64-bit* Ubuntu/Debian systems
 
 1. Install Ubuntu 14.04 or Debian 7.5 64-bit.
 2. Install the packages necessary for the build:
-> sudo apt-get install cscope ctags libz-dev libexpat-dev libc6-dev-i386 gcc g++ git bison flex gcc-multilib g++-multilib libxml-simple-perl libxml-sax-perl libxml2-dev
+> sudo apt-get install cscope ctags libz-dev libexpat-dev libc6-dev-i386 \
+  build-essential g++ git bison flex gcc-multilib g++-multilib \
+  libxml-simple-perl libxml-sax-perl libxml2-dev libxml2-utils xsltproc
 3. Continue with the clone, environment setup, and build as noted above.
 
 Building on *64-bit* Fedora systems

--- a/openpower/package/p8-pore-binutils/p8-pore-binutils.mk
+++ b/openpower/package/p8-pore-binutils/p8-pore-binutils.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-P8_PORE_BINUTILS_VERSION ?= 94a1a56cb3ce72a2d6202ab54206912cf9e1feb1
+P8_PORE_BINUTILS_VERSION ?= dcf4f87c0d9e8c8092ace0eb696189ee1056da30
 P8_PORE_BINUTILS_SITE ?= $(call github,open-power,p8-pore-binutils,$(P8_PORE_BINUTILS_VERSION))
 P8_PORE_BINUTILS_LICENSE = GPLv3+
 


### PR DESCRIPTION
These two updates are for issues I found when building on Ubuntu 14.10. The update to p8-pore-binutils fixes building with gcc-4.9 host compilers.

The readme is updated with dependences that I found weren't installed on a Ubuntu 14.10 server install.