### PR TITLE
skiboot: Update to 9a3f68b

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = 9a3f68b499e686ff3b543633f59192890f6c740b
+SKIBOOT_VERSION = 5dea3e71fc7fd13d7a2aeb966d78043b74227394
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
This change brings us to 5.0-rc1, plus two openpower-specific fixes.

Alistair Popple (1):
      memboot: Add a memboot flash backend

Ananth N Mavinakayanahalli (1):
      fsp: Fix FSP irq initialization on PSIHBCR for resets

Anshuman Khandual (3):
      FSP/LEDS: Modify handling of SPCN based LED commands
      FSP/LEDS: Serialize the entire LED state change code and it's callback
      FSP/LEDS: Roll back LED state update in case FSP command queuing fails

Benjamin Herrenschmidt (1):
      Fixup "i" command in mambo scripts

Cyril Bur (2):
      libflash: endian fixups for ecc.c
      libflash: Improved ECC interface

Cédric Le Goater (15):
      sparse: rtc_tod_state and rtc_tod_cache_dirty and be static
      sparse: bt_backend can be static
      flash: fix return value of flash_find_subpartition()
      core: add a platform op to read sensors
      dts: add support to read the core temperatures
      dts: add device tree nodes for the core temperatures
      dts: add a status property
      dts: add a type property
      dts: add some extra properties to improve the driver
      dts: add device tree documentation
      dts: add memory buffers temperature sensors
      sensor: add documentation for the OPAL_SENSOR_READ call
      sensor: return OPAL_UNSUPPORTED when no sensors are supported
      fsp-sensor: add a label property for the ambient sensor
      Fix start_preload_resource for OpenPower BMC machines

Dan Streetman (3):
      move nx-842 ct and ci nodes into main nx node
      Add NX P7+ support
      update device tree doc for NX node location

Daniel Axtens (4):
      core/test: Test that device paths/names function as expected.
      core/test: Use "" as the name of the device tree root node.
      core/test: Test more get/set functions in device.c
      core/test: Test compatible, chip id and phandle related DT functions

Jeremy Kerr (4):
      external/opal-prd: Add a helper for module loading
      external/opal-prd: Unify logging calls and log to syslog
      doc/device-tree: Add descriptions for the ibm, pstate-* properties.
      external/opal-prd: Use "official" switch-endian syscall

Joel Stanley (4):
      external/opal-prd: Enhance PNOR error messages
      external/opal-prd: Allow partial ops with PNOR API
      external/opal-prd: Correct partition offset
      hw/ipmi: Rework sensors and fix boot count sensor

Mahesh Salgaonkar (13):
      opal: Enhance HMI event structure to accommodate checkstop info.
      opal: Update doc/opal-api/opal-messages.txt
      opal: Check Core FIRs to find the reason for Malfunction Alert.
      opal: Check NX FIRs to find the reason for Malfunction Alert.
      Revert "opal: Handle more TFAC errors."
      opal: Refactor tb errors reset code
      opal: Recover from TB residue error.
      opal: Handle TFMR firmware control error.
      opal: Handle TFMR parity HMI event.
      opal: Recover from TFMR HDEC parity error.
      opal: Recover from TFMR DEC parity error.
      opal: Recover from TFMR SPURR/PURR parity error.
      opal: Handle TB residue and HDEC parity HMI errors on split core.

Neelesh Gupta (2):
      fsp/rtc: Rename the rtc_request_state to rtc_read_request_state
      fsp/rtc: Introduce the rtc write state machine

Stewart Smith (6):
      Refactor fsp-rtc.c to not call fsp_sync_msg (and thus pollers) with lock held
      Merge branch 'openpower'
      trailing whitespace cleanup in p7ioc.c
      Add basic OPAL_XSCOM_READ and OPAL_XSCOM_WRITE docs
      Change load_resource() API to be all about preloading.
      Asynchronous LID/Resource loading for FSP systems

Vasant Hegde (17):
      OCC: Do not call occ_do_load if hostservice LID load is not complete
      OCC: Fix possible memory leak in error path
      FSP/RTC: Check for TOD state in fsp_opal_rtc_read
      PHB3: Do not release unhold lock in error path
      hdata: Convert printf based log messages to prlog based logs
      hdata: Fix location code size
      OPAL: Detect recursive poller entry from same CPU
      FSP/LEDS: Add device tree nodes
      FSP/LEDS: Move checkpoint status variable to led_set_cmd structure
      FSP/LEDS: Handle failure cases in set LED MBOX command
      FSP/LEDS: Add OPAL interfaces for accessing or modifying the LED states
      FSP/LEDS: Roll back exclusive bit in case FSP command queuing fails
      FSP/SYSPARAM: Fix memory leak in error path
      OCC/hostservices: Call abort if hbrt_lid_list is empty
      FSP: Serialize FSP MBOX command declaration
      FSP/LED: Continue processing LED update request in error path
      FSP/LED: Validate before creating LED nodes

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>