### PR TITLE
Habanero Updates for SL

### DIFF
--- a/openpower/package/habanero-xml/habanero-xml-0001-Revert-Merge-pull-request-18-from-open-power-bofferd.patch
+++ b/openpower/package/habanero-xml/habanero-xml-0001-Revert-Merge-pull-request-18-from-open-power-bofferd.patch
@@ -1,0 +1,84 @@
+From b1eb2395a4bf796603cb34aa5913f43b84c42855 Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Tue, 31 Mar 2015 07:56:06 -0500
+Subject: [PATCH] Revert "Merge pull request #18 from
+ open-power/bofferdn-hab-loadline"
+
+This reverts commit ddb962894919657517f0d9bca4540a427953f987, reversing
+changes made to a98bf456ff5d9f18dc2af1ffc59d67a302029a76.
+
+Conflicts:
+	habanero.xml
+---
+ habanero.xml | 48 ++++++++++++++++++++++++------------------------
+ 1 file changed, 24 insertions(+), 24 deletions(-)
+
+diff --git a/habanero.xml b/habanero.xml
+index 8768f72..1aa85a8 100644
+--- a/habanero.xml
++++ b/habanero.xml
+@@ -4967,6 +4967,30 @@
+ 		<default>1</default>
+ 	</attribute>
+ 	<attribute>
++		<id>PROC_R_DISTLOSS_VCS</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_R_DISTLOSS_VDD</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_R_LOADLINE_VCS</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_R_LOADLINE_VDD</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_VRM_VOFFSET_VCS</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_VRM_VOFFSET_VDD</id>
++		<default></default>
++	</attribute>
++	<attribute>
+ 		<id>PROC_X_BUS_WIDTH</id>
+ 		<default>2</default>
+ 	</attribute>
+@@ -6996,30 +7020,6 @@
+ 		<default>0</default>
+ 	</attribute>
+ 	<attribute>
+-		<id>PROC_R_DISTLOSS_VCS</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_R_DISTLOSS_VDD</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_R_LOADLINE_VCS</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_R_LOADLINE_VDD</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_VRM_VOFFSET_VCS</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_VRM_VOFFSET_VDD</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+ 		<id>PSI_BRIDGE_BASE_ADDR</id>
+ 		<default>0,0x0000000000000000</default>
+ 	</attribute>
+-- 
+1.8.2.2
+

--- a/openpower/package/habanero-xml/habanero-xml-0002-Add-System-Fw-Fru-Id.patch
+++ b/openpower/package/habanero-xml/habanero-xml-0002-Add-System-Fw-Fru-Id.patch
@@ -1,0 +1,27 @@
+From d1fa8a2e10849a388e09f94dd25dc9008951c1c8 Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Tue, 31 Mar 2015 07:43:23 -0500
+Subject: [PATCH] Add System Fw Fru Id
+
+---
+ habanero.xml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/habanero.xml b/habanero.xml
+index 1aa85a8..16976a7 100644
+--- a/habanero.xml
++++ b/habanero.xml
+@@ -4667,6 +4667,10 @@
+ 		<default></default>
+ 	</attribute>
+ 	<attribute>
++	        <id>BMC_FRU_ID</id>
++	        <default>43</default>
++        </attribute>
++	<attribute>
+ 		<id>FRU_NAME</id>
+ 		<default></default>
+ 	</attribute>
+-- 
+1.8.2.2
+

--- a/openpower/package/habanero-xml/habanero-xml.mk
+++ b/openpower/package/habanero-xml/habanero-xml.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HABANERO_XML_VERSION ?= 4c1e936c0329384020b126efe69d2148cfe48960
+HABANERO_XML_VERSION ?= 4173b205b0a7dfd18a97f3a0d5319c9aad893035
 HABANERO_XML_SITE ?= $(call github,open-power,habanero-xml,$(HABANERO_XML_VERSION))
 
 HABANERO_XML_LICENSE = Apache-2.0

--- a/openpower/package/hostboot/hostboot-0008-Update-SBE-Update-IPMI-Watchdog-call-to-use-HARD_RES.patch
+++ b/openpower/package/hostboot/hostboot-0008-Update-SBE-Update-IPMI-Watchdog-call-to-use-HARD_RES.patch
@@ -1,0 +1,33 @@
+From a048585e96058e9bf1ba43853de3a6b70053d740 Mon Sep 17 00:00:00 2001
+From: Mike Baiocchi <baiocchi@us.ibm.com>
+Date: Thu, 26 Mar 2015 13:16:18 -0500
+Subject: [PATCH 1/5] Update SBE Update IPMI Watchdog call to use HARD_RESET
+ action
+
+This commit updates how the SBE Update code will setup the IPMI
+watchdog timer before calling doShutdown().  Rather than using
+NO_ACTIONS, the updated code will use the HARD_RESET action.
+
+Change-Id: Id251307aa76259d8a290a92d9e9f3418b181bc3e
+RTC: 124679
+(cherry picked from commit 815998ab802c19ade01cdc71a9e59946eedf1ab1)
+---
+ src/usr/sbe/sbe_resolve_sides.C | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/usr/sbe/sbe_resolve_sides.C b/src/usr/sbe/sbe_resolve_sides.C
+index 49d2c25..26ac4e6 100644
+--- a/src/usr/sbe/sbe_resolve_sides.C
++++ b/src/usr/sbe/sbe_resolve_sides.C
+@@ -1350,7 +1350,7 @@ void sbePreShutdownIpmiCalls( void )
+                                static_cast<uint8_t>
+                                           (IPMIWATCHDOG::DO_NOT_STOP |
+                                            IPMIWATCHDOG::BIOS_FRB2), // default
+-                               IPMIWATCHDOG::NO_ACTIONS); // boot count reset
++                               IPMIWATCHDOG::TIMEOUT_HARD_RESET);
+         if(err)
+         {
+                TRACFCOMP( g_trac_sbe,
+-- 
+1.8.2.2
+

--- a/openpower/package/hostboot/hostboot-0009-Reject-IPMI-events-which-arent-destined-for-the-host.patch
+++ b/openpower/package/hostboot/hostboot-0009-Reject-IPMI-events-which-arent-destined-for-the-host.patch
@@ -1,0 +1,142 @@
+From 1e70ee010552ad835b03751ebf4788e367bcecd4 Mon Sep 17 00:00:00 2001
+From: Brian Silver <bsilver@us.ibm.com>
+Date: Thu, 26 Mar 2015 15:34:54 -0500
+Subject: [PATCH 2/5] Reject IPMI events which aren't destined for the host
+
+Change-Id: I378e0763c5ca8c13830d0e6c057b24e6beb5dc8c
+(cherry picked from commit e7b68743f7d2a160fd1dd3019f5614860576de64)
+---
+ src/include/usr/ipmi/ipmiif.H |  8 ++++
+ src/usr/ipmi/ipmirp.C         | 92 +++++++++++++++++++++++++++----------------
+ 2 files changed, 65 insertions(+), 35 deletions(-)
+
+diff --git a/src/include/usr/ipmi/ipmiif.H b/src/include/usr/ipmi/ipmiif.H
+index 56e3c53..e65252a 100644
+--- a/src/include/usr/ipmi/ipmiif.H
++++ b/src/include/usr/ipmi/ipmiif.H
+@@ -88,6 +88,14 @@ namespace IPMI
+         NETFUN_NONE     = (0x30 << 2),
+     };
+ 
++    // SMS_ATN OEM Event constants
++    enum oem_event
++    {
++        OEM_VALID_NETFUN      = 0x3a,
++        OEM_VALID_SEL_ID      = 0x5555,
++        OEM_VALID_RECORD_TYPE = 0xC0,
++    };
++
+     // IPMI Completion Codes
+     enum completion_code
+     {
+diff --git a/src/usr/ipmi/ipmirp.C b/src/usr/ipmi/ipmirp.C
+index 5925d45..de1b219 100644
+--- a/src/usr/ipmi/ipmirp.C
++++ b/src/usr/ipmi/ipmirp.C
+@@ -331,46 +331,68 @@ void IpmiRP::postEvent(IPMI::oemSEL* i_event)
+ {
+     // Called in the context of the RP message loop, mutex locked
+ 
+-    // Check to see if this event has a queue registered
+-    IPMI::event_q_t::iterator it = iv_eventq.find(i_event->iv_cmd[0]);
++    do {
++        // Check to see if event is valid. AMI recomends we check the netfun,
++        // the SEL id, and the record id. If they don't match, we're allowed
++        // to consider this an unhandled message.
++        if ( (i_event->iv_netfun      != IPMI::OEM_VALID_NETFUN) ||
++             (i_event->iv_record      != IPMI::OEM_VALID_SEL_ID) ||
++             (i_event->iv_record_type != IPMI::OEM_VALID_RECORD_TYPE) )
++        {
++            IPMI_TRAC("rejecting event netfun: 0x%x record: 0x%x record type: 0x%x cmd: 0x%x",
++                      i_event->iv_netfun,
++                      i_event->iv_record,
++                      i_event->iv_record_type,
++                      i_event->iv_cmd[0]);
+ 
+-    msg_q_t outq = (it == iv_eventq.end()) ? iv_last_chanceq : it->second;
++            // ... and clean up the memory for the caller
++            delete i_event;
++            break;
++        }
+ 
+-    // Create a message to send asynchronously to the event handler queue
+-    // Assign the event to the message, the caller will delete the message
+-    // and the event.
+-    msg_t* msg = msg_allocate();
+-    msg->type = IPMI::TYPE_EVENT;
+-    msg->extra_data = i_event;
++        // Check to see if this event has a queue registered
++        IPMI::event_q_t::iterator it = iv_eventq.find(i_event->iv_cmd[0]);
++        msg_q_t outq = (it == iv_eventq.end()) ? iv_last_chanceq : it->second;
+ 
+-    IPMI_TRAC("queuing event %x:%x for handler",
+-              i_event->iv_netfun, i_event->iv_cmd[0])
+-    int rc = msg_send(outq, msg);
++        // Create a message to send asynchronously to the event handler queue
++        // Assign the event to the message, the caller will delete the message
++        // and the event.
++        msg_t* msg = msg_allocate();
++        msg->type = IPMI::TYPE_EVENT;
++        msg->extra_data = i_event;
+ 
+-    if (rc)
+-    {
+-        /* @errorlog tag
+-         * @errortype       ERRL_SEV_UNRECOVERABLE
+-         * @moduleid        IPMI::MOD_IPMISRV_SEND
+-         * @reasoncode      IPMI::RC_INVALID_SEND
+-         * @userdata1       rc from msq_send()
+-         * @devdesc         msg_send() failed
+-         * @custdesc        Firmware error during IPMI event handling
+-         */
+-        errlHndl_t err =
+-            new ERRORLOG::ErrlEntry(ERRORLOG::ERRL_SEV_UNRECOVERABLE,
+-                                    IPMI::MOD_IPMISRV_SEND,
+-                                    IPMI::RC_INVALID_SEND,
+-                                    rc,
+-                                    0,
+-                                    true);
+-        err->collectTrace(IPMI_COMP_NAME);
+-        errlCommit(err, IPMI_COMP_ID);
++        IPMI_TRAC("queuing event %x:%x for handler",
++                  i_event->iv_netfun, i_event->iv_cmd[0])
++            int rc = msg_send(outq, msg);
+ 
+-        // ... and clean up the memory for the caller
+-        delete i_event;
+-        msg_free(msg);
+-    }
++        if (rc)
++        {
++            /* @errorlog tag
++             * @errortype       ERRL_SEV_UNRECOVERABLE
++             * @moduleid        IPMI::MOD_IPMISRV_SEND
++             * @reasoncode      IPMI::RC_INVALID_SEND
++             * @userdata1       rc from msq_send()
++             * @devdesc         msg_send() failed
++             * @custdesc        Firmware error during IPMI event handling
++             */
++            errlHndl_t err =
++                new ERRORLOG::ErrlEntry(ERRORLOG::ERRL_SEV_UNRECOVERABLE,
++                                        IPMI::MOD_IPMISRV_SEND,
++                                        IPMI::RC_INVALID_SEND,
++                                        rc,
++                                        0,
++                                        true);
++            err->collectTrace(IPMI_COMP_NAME);
++            errlCommit(err, IPMI_COMP_ID);
++
++            // ... and clean up the memory for the caller
++            delete i_event;
++            msg_free(msg);
++        }
++
++    } while(0);
++
++    return;
+ }
+ 
+ /**
+-- 
+1.8.2.2
+

--- a/openpower/package/hostboot/hostboot-0010-Support-partial-good-Xbus.patch
+++ b/openpower/package/hostboot/hostboot-0010-Support-partial-good-Xbus.patch
@@ -1,0 +1,71 @@
+From 07b936c1c5f97314719e7e988e6c07810637b8c1 Mon Sep 17 00:00:00 2001
+From: Dean Sanner <dsanner@us.ibm.com>
+Date: Wed, 11 Mar 2015 09:11:14 -0500
+Subject: [PATCH 3/8] Support partial good Xbus
+
+Change-Id: I245cd9947d5b7a05ff9a8f92ff18c658b1fe09d6
+Reviewed-on: http://gfw160.aus.stglabs.ibm.com:8080/gerrit/16300
+Tested-by: Jenkins Server
+Reviewed-by: Daniel M. Crowell <dcrowell@us.ibm.com>
+Reviewed-by: Brian H. Horton <brianh@linux.ibm.com>
+Reviewed-by: A. Patrick Williams III <iawillia@us.ibm.com>
+(cherry picked from commit a0f4a934254572ce49a1ddf5e4d5d944b52779be)
+---
+ src/usr/hwpf/plat/fapiPlatAttributeService.C | 22 ++++++++++++++++++----
+ 1 file changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/src/usr/hwpf/plat/fapiPlatAttributeService.C b/src/usr/hwpf/plat/fapiPlatAttributeService.C
+index 6e4f400..7da841a 100644
+--- a/src/usr/hwpf/plat/fapiPlatAttributeService.C
++++ b/src/usr/hwpf/plat/fapiPlatAttributeService.C
+@@ -58,11 +58,14 @@
+ #include <hwpf/hwp/pll_accessors/getPllRingInfoAttr.H>
+ #include <hwpf/hwp/winkle_ring_accessors/getL3DeltaDataAttr.H>
+ #include <fapiAttributeIds.H>
++#include <hwas/common/hwasCommon.H>
++
+ // The following file checks at compile time that all HWPF attributes are
+ // handled by Hostboot. This is done to ensure that the HTML file listing
+ // supported HWPF attributes lists attributes handled by Hostboot
+ #include <fapiAttributePlatCheck.H>
+ 
++
+ //******************************************************************************
+ // Implementation
+ //******************************************************************************
+@@ -1239,6 +1242,7 @@ fapi::ReturnCode fapiPlatGetEnableAttr ( fapi::AttributeId i_id,
+ {
+     fapi::ReturnCode l_rc;
+     TARGETING::Target * l_pTarget = NULL;
++    o_enable = 0;
+ 
+     // Get the Targeting Target
+     l_rc = getTargetingTarget(i_pFapiTarget, l_pTarget);
+@@ -1271,10 +1275,20 @@ fapi::ReturnCode fapiPlatGetEnableAttr ( fapi::AttributeId i_id,
+                 o_enable = 1;
+                 break;
+             case fapi::ATTR_PROC_X_ENABLE:
+-                // The enable flag reflects the state of the pervasive chiplet,
+-                //  NOT the bus logic, so always return true since we don't
+-                //  support partial good on the XBUS chiplet
+-                o_enable = 1;
++                // Need to support having the X bus chiplet partial good
++                // Look at the saved away PG data
++                TARGETING::ATTR_CHIP_REGIONS_TO_ENABLE_type l_chipRegionData;
++                l_rc = FAPI_ATTR_GET(ATTR_CHIP_REGIONS_TO_ENABLE, i_pFapiTarget,
++                                     l_chipRegionData);
++                if (l_rc) {
++                    FAPI_ERR("fapi_attr_get( ATTR_CHIP_REGIONS_TO_ENABLE ) failed. With rc = 0x%x",
++                             (uint32_t) l_rc );
++                    break;
++                }
++                else if (l_chipRegionData[HWAS::VPD_CP00_PG_XBUS_INDEX] != 0)
++                {
++                    o_enable = 0x1;
++                }
+                 break;
+             default:
+                 o_enable = 0;
+-- 
+1.8.2.2
+

--- a/openpower/package/hostboot/hostboot-0011-Pull-model-name-and-serial-from-OSYS-record-if-avail.patch
+++ b/openpower/package/hostboot/hostboot-0011-Pull-model-name-and-serial-from-OSYS-record-if-avail.patch
@@ -1,0 +1,213 @@
+From 438ebf4b5acbaab0da69009d4248a6aac45fbed6 Mon Sep 17 00:00:00 2001
+From: Dan Crowell <dcrowell@us.ibm.com>
+Date: Wed, 11 Mar 2015 16:44:59 -0500
+Subject: [PATCH 3/5] Pull model name and serial from OSYS record if available
+
+The supported level of OP planar VPD has the system model
+name inside OSYS:MM, not OPFR:DR.
+
+Change-Id: Iaa9c4e00325f8fa6efb7a9fca1275bcea2759308
+Reviewed-on: http://gfw160.aus.stglabs.ibm.com:8080/gerrit/16308
+Reviewed-by: William H. Schwartz <whs@us.ibm.com>
+Tested-by: Jenkins Server
+Reviewed-by: A. Patrick Williams III <iawillia@us.ibm.com>
+(cherry picked from commit 2114a66c76558f41cd305fc294ccdfaf6607c0e5)
+---
+ src/usr/devtree/bld_devtree.C | 142 +++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 126 insertions(+), 16 deletions(-)
+
+diff --git a/src/usr/devtree/bld_devtree.C b/src/usr/devtree/bld_devtree.C
+index f2e9438..622178a 100644
+--- a/src/usr/devtree/bld_devtree.C
++++ b/src/usr/devtree/bld_devtree.C
+@@ -1034,18 +1034,26 @@ errlHndl_t bld_fdt_system(devTree * i_dt, bool i_smallTree)
+     // Nothing to do for small trees currently.
+     if (!i_smallTree)
+     {
++        //===== compatible =====
+         /* Fetch the MRW-defined compatible model from attributes */
+         ATTR_OPAL_MODEL_type l_model = {0};
+         TARGETING::Target* sys = NULL;
+         TARGETING::targetService().getTopLevelTarget(sys);
+         sys->tryGetAttr<TARGETING::ATTR_OPAL_MODEL>(l_model);
+ 
+-        /* Add compatibility node */
++        /* Add compatibility value */
+         const char* l_compats[] = { "ibm,powernv", l_model, NULL };
+         i_dt->addPropertyStrings(rootNode, "compatible", l_compats);
+ 
+-        /* Add system model node */
+-        // Based off of the DR field in the OPFR
++        //===== model =====
++        /* Add system model value
++           Depending on the vintage of the planar VPD, there are 3 places
++           we need to look for this data.
++           1) OSYS:MM
++           2) OPFR:DR
++           3) Default to 'unknown'
++         */
++        bool foundvpd = false;
+         // TODO RTC 118373 -- update to account for firestone/memory riser
+         TARGETING::TargetHandleList l_membTargetList;
+         getAllChips(l_membTargetList, TYPE_MEMBUF);
+@@ -1061,42 +1069,144 @@ errlHndl_t bld_fdt_system(devTree * i_dt, bool i_smallTree)
+             errhdl = deviceRead( l_pMem,
+                                  NULL,
+                                  vpdSize,
+-                                 DEVICE_CVPD_ADDRESS( CVPD::OPFR,
+-                                                      CVPD::DR ));
++                                 DEVICE_CVPD_ADDRESS( CVPD::OSYS,
++                                                      CVPD::MM ));
+ 
+             if(errhdl)
+             {
+-                TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't get DR size for HUID=0x%.8X",
++                TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't get OSYS:MM size for HUID=0x%.8X",
+                           TARGETING::get_huid(l_pMem));
+-                i_dt->addPropertyString(rootNode, "model", "unknown");
+-                errlCommit(errhdl, DEVTREE_COMP_ID);
++
++                // Try the OPFR record
++                errlHndl_t opfr_errhdl = deviceRead( l_pMem,
++                                           NULL,
++                                           vpdSize,
++                                           DEVICE_CVPD_ADDRESS( CVPD::OPFR,
++                                                                CVPD::DR ));
++                if(opfr_errhdl)
++                {
++                    TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't get OPFR:DR size for HUID=0x%.8X",
++                              TARGETING::get_huid(l_pMem));
++                    delete opfr_errhdl; //delete OPFR log, VPD is just bad
++                }
++                else
++                {
++                    delete errhdl; //ignore lack of OSYS due to older vpd
++                    errhdl = NULL;
++                    char drBuf[vpdSize+1];
++                    memset(&drBuf, 0x0, (vpdSize+1)); //null terminated str
++                    errhdl = deviceRead( l_pMem,
++                                         reinterpret_cast<void*>( &drBuf ),
++                                         vpdSize,
++                                         DEVICE_CVPD_ADDRESS( CVPD::OPFR,
++                                                              CVPD::DR ));
++
++                    if(errhdl)
++                    {
++                        TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't read OPFR:DR for HUID=0x%.8X",
++                                  TARGETING::get_huid(l_pMem));
++                    }
++                    else
++                    {
++                        foundvpd = true;
++                        i_dt->addPropertyString(rootNode, "model", drBuf);
++                    }
++                }
+             }
+             else
+             {
+-                char drBuf[vpdSize+1];
+-                memset(&drBuf, 0x0, (vpdSize+1)); //ensure null terminated str
++                char mmBuf[vpdSize+1];
++                memset(&mmBuf, 0x0, (vpdSize+1)); //ensure null terminated str
+                 errhdl = deviceRead( l_pMem,
+-                                     reinterpret_cast<void*>( &drBuf ),
++                                     reinterpret_cast<void*>( &mmBuf ),
+                                      vpdSize,
+-                                     DEVICE_CVPD_ADDRESS( CVPD::OPFR,
+-                                                          CVPD::DR ));
++                                     DEVICE_CVPD_ADDRESS( CVPD::OSYS,
++                                                          CVPD::MM ));
+ 
+                 if(errhdl)
+                 {
+-                    TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't read DR for HUID=0x%.8X",
++                    TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't read OSYS:MM for HUID=0x%.8X",
+                               TARGETING::get_huid(l_pMem));
+                 }
+                 else
+                 {
+-                    i_dt->addPropertyString(rootNode, "model", drBuf);
++                    foundvpd = true;
++                    i_dt->addPropertyString(rootNode, "model", mmBuf);
+                 }
+             }
+         }
+-        else //chassis info not found, default to unknown
++
++        // just commit any errors we get, this isn't critical
++        if( errhdl )
++        {
++            errlCommit(errhdl, DEVTREE_COMP_ID); //commit original OSYS log
++        }
++
++        if( !foundvpd ) //chassis info not found, default to unknown
+         {
+             TRACFCOMP(g_trac_devtree,ERR_MRK" VPD not found, model defaulted to unknown");
+             i_dt->addPropertyString(rootNode, "model", "unknown");
+         }
++
++        //===== system-id =====
++        /* Add system-id value
++           1) OSYS:SS
++           2) Default to 'unavailable'
++         */
++        // TODO RTC 118373 -- update to account for firestone/memory riser
++        foundvpd = false;
++        if( l_membTargetList.size() )
++        {
++            // TODO RTC 118373 - Should be able to read from attribute
++            TARGETING::Target * l_pMem = l_membTargetList[0];
++            size_t vpdSize = 0x0;
++
++            // Note: First read with NULL for o_buffer sets vpdSize to the
++            // correct length
++            errhdl = deviceRead( l_pMem,
++                                 NULL,
++                                 vpdSize,
++                                 DEVICE_CVPD_ADDRESS( CVPD::OSYS,
++                                                      CVPD::SS ));
++
++            if(errhdl)
++            {
++                TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't get OSYS:SS size for HUID=0x%.8X",
++                          TARGETING::get_huid(l_pMem));
++                // Note - not supporting old vpd versions without OSYS here
++            }
++            else
++            {
++                char ssBuf[vpdSize+1];
++                memset(&ssBuf, 0x0, (vpdSize+1)); //ensure null terminated str
++                errhdl = deviceRead( l_pMem,
++                                     reinterpret_cast<void*>( &ssBuf ),
++                                     vpdSize,
++                                     DEVICE_CVPD_ADDRESS( CVPD::OSYS,
++                                                          CVPD::SS ));
++
++                if(errhdl)
++                {
++                    TRACFCOMP(g_trac_devtree,ERR_MRK" Couldn't read OSYS:SS for HUID=0x%.8X",
++                              TARGETING::get_huid(l_pMem));
++                }
++                else
++                {
++                    foundvpd = true;
++                    i_dt->addPropertyString(rootNode, "system-id", ssBuf);
++                }
++            }
++        }
++        // just commit any errors we get, this isn't critical
++        if( errhdl )
++        {
++            errlCommit(errhdl, DEVTREE_COMP_ID);
++        }
++
++        if( !foundvpd ) //serial number not found, default to unavailable
++        {
++            i_dt->addPropertyString(rootNode, "system-id", "unavailable");
++        }
+     }
+ 
+     return errhdl;
+-- 
+1.8.2.2
+

--- a/openpower/package/hostboot/hostboot-0012-Cap-off-the-TRACFBIN-such-that-nothing-exceeds-64-by.patch
+++ b/openpower/package/hostboot/hostboot-0012-Cap-off-the-TRACFBIN-such-that-nothing-exceeds-64-by.patch
@@ -1,0 +1,57 @@
+From 22c58d6a7d3e6d69294aa16c9b0fa354ae9cf861 Mon Sep 17 00:00:00 2001
+From: Elizabeth Liner <eliner@us.ibm.com>
+Date: Mon, 30 Mar 2015 12:41:45 -0500
+Subject: [PATCH 4/5] Cap off the TRACFBIN such that nothing exceeds 64 bytes
+
+Change-Id: If8f08d1602b4437aa0e72e6d2e8d99ca615a2c77
+(cherry picked from commit cb2ea9c1b5d1906e0f58eda347367c648c18809a)
+---
+ src/include/usr/trace/interface.H | 16 +++++++++++-----
+ src/include/usr/trace/trace.H     |  2 ++
+ 2 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/src/include/usr/trace/interface.H b/src/include/usr/trace/interface.H
+index 3ef8575..d02db76 100644
+--- a/src/include/usr/trace/interface.H
++++ b/src/include/usr/trace/interface.H
+@@ -218,13 +218,19 @@ const uint32_t TRACE_FIELD   = 0;       //Indicates trace is field
+ */
+ #define TRACFBIN(des,printf_string,address,len) \
+     { \
++        uint16_t l_length = len; \
++        if(len > MAX_WORKING_TRACBIN_SIZE) \
++        { \
++            l_length = MAX_WORKING_TRACBIN_SIZE; \
++            TRACFCOMP(des,"Shrinking to max size in TRACFBIN"); \
++        } \
+         __TRACE_HASH_STRUCTURES(printf_string); \
+         TRACE::trace_adal_write_bin((des), \
+-                                    &__traceData_codeInfo, \
+-                                    __LINE__, \
+-                                    address, \
+-                                    len, \
+-                                    TRACE_FIELD); \
++                                &__traceData_codeInfo, \
++                                __LINE__, \
++                                address, \
++                                l_length, \
++                                TRACE_FIELD); \
+     }
+ 
+ /**
+diff --git a/src/include/usr/trace/trace.H b/src/include/usr/trace/trace.H
+index fdcce88..e969487 100644
+--- a/src/include/usr/trace/trace.H
++++ b/src/include/usr/trace/trace.H
+@@ -42,6 +42,8 @@ const uint32_t TRACE_DEBUG_OFF   = 0;       //< Set to this when debug trace off
+ const uint32_t TRAC_COMP_SIZE    = 16;      //< Max component name size
+ const uint32_t TRAC_MAX_ARGS     = 9;       //< Max number of arguments in trace
+ 
++const uint16_t MAX_WORKING_TRACBIN_SIZE = 64; //< Max working tracBin size
++
+ typedef uint32_t trace_hash_val;    //< Hash values are 32 bits.
+ 
+ 
+-- 
+1.8.2.2
+

--- a/openpower/package/hostboot/hostboot-0013-Enable-vrml-mvpd.patch
+++ b/openpower/package/hostboot/hostboot-0013-Enable-vrml-mvpd.patch
@@ -1,0 +1,38 @@
+From a5d5840c4780a39be436e2dde2a53037b1b82635 Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Mon, 30 Mar 2015 19:22:44 -0500
+Subject: [PATCH] Add VRML MVPD Enablement for Habanero
+
+Change-Id: I7dd2d155e295a5fee09010ba173c82748e25221d
+---
+ src/include/usr/vpd/mvpdenums.H | 1 +
+ src/usr/vpd/mvpd.H              | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/include/usr/vpd/mvpdenums.H b/src/include/usr/vpd/mvpdenums.H
+index 950245f..fd4ddaf 100644
+--- a/src/include/usr/vpd/mvpdenums.H
++++ b/src/include/usr/vpd/mvpdenums.H
+@@ -79,6 +79,7 @@ enum mvpdRecord
+     LWPE        = 0x20,
+     VWML        = 0x21,
+     MER0        = 0x22,
++    VRML        = 0x23,
+ 
+     // Last Record
+     MVPD_LAST_RECORD,
+diff --git a/src/usr/vpd/mvpd.H b/src/usr/vpd/mvpd.H
+index 60a8491..e9fe905 100644
+--- a/src/usr/vpd/mvpd.H
++++ b/src/usr/vpd/mvpd.H
+@@ -88,6 +88,7 @@ namespace MVPD
+         { LWPE, "LWPE" },
+         { VWML, "VWML" },
+         { MER0, "MER0" },
++        { VRML, "VRML" },
+         // -------------------------------------------------------------------
+         // DO NOT USE!!  This is for test purposes ONLY!
+         { MVPD_TEST_RECORD, "TEST" },
+-- 
+1.8.2.2
+

--- a/openpower/package/hostboot/hostboot-0014-Update-VPD-Fields-Use-for-Fru-Inventory.patch
+++ b/openpower/package/hostboot/hostboot-0014-Update-VPD-Fields-Use-for-Fru-Inventory.patch
@@ -1,0 +1,203 @@
+From 1521a501ada30fd69606829b8f551547d7d882cd Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Mon, 30 Mar 2015 11:09:17 -0500
+Subject: [PATCH 5/5] Update VPD Fields Use for Fru Inventory
+
+Change-Id: Iaa4802e72e355acd03cb88e58c40d1069dd76ef5
+RTC:125044
+(cherry picked from commit 8a7427bd44bd4742a53412e6894cc2294d893012)
+---
+ src/usr/ipmi/ipmifruinv.C     | 97 +++++++++++++++++--------------------------
+ src/usr/ipmi/ipmifruinvprvt.H |  6 ++-
+ 2 files changed, 42 insertions(+), 61 deletions(-)
+
+diff --git a/src/usr/ipmi/ipmifruinv.C b/src/usr/ipmi/ipmifruinv.C
+index 7c9eb85..c6c7a30 100644
+--- a/src/usr/ipmi/ipmifruinv.C
++++ b/src/usr/ipmi/ipmifruinv.C
+@@ -35,6 +35,7 @@
+ #include <ipmi/ipmifruinv.H>
+ #include "ipmifru.H"
+ #include "ipmifruinvprvt.H"
++#include <stdio.h>
+ 
+ extern trace_desc_t * g_trac_ipmi;
+ 
+@@ -401,7 +402,7 @@ errlHndl_t isdimmIpmiFruInv::buildProductInfoArea(std::vector<uint8_t> &io_data)
+         l_errl = addVpdData(io_data, SPD::BASIC_MEMORY_TYPE);
+         if (l_errl) { break; }
+         //Set Product Part/Model Number
+-        l_errl = addVpdData(io_data, SPD::MODULE_PART_NUMBER);
++        l_errl = addVpdData(io_data, SPD::MODULE_PART_NUMBER, true);
+         if (l_errl) { break; }
+         //Set Product Version
+         l_errl = addVpdData(io_data, SPD::MODULE_REVISION_CODE);
+@@ -411,8 +412,7 @@ errlHndl_t isdimmIpmiFruInv::buildProductInfoArea(std::vector<uint8_t> &io_data)
+         if (l_errl) { break; }
+ 
+         //Add Asset Tag
+-        io_data.push_back(uint8_t(1)); //Asset Tag is One Byte for now
+-        io_data.push_back(uint8_t(0));
++        io_data.push_back(uint8_t(0)); //No Asset Tag needed - O bytes
+ 
+         //FRU File ID - Empty
+         io_data.push_back(IPMIFRUINV::TYPELENGTH_BYTE_NULL);
+@@ -434,7 +434,8 @@ errlHndl_t isdimmIpmiFruInv::buildProductInfoArea(std::vector<uint8_t> &io_data)
+ }
+ 
+ errlHndl_t isdimmIpmiFruInv::addVpdData(std::vector<uint8_t> &io_data,
+-                                     uint8_t i_keyword)
++                                     uint8_t i_keyword,
++                                     bool i_ascii)
+ {
+     size_t     l_vpdSize = 0;
+     errlHndl_t l_errl = NULL;
+@@ -463,12 +464,22 @@ errlHndl_t isdimmIpmiFruInv::addVpdData(std::vector<uint8_t> &io_data,
+             uint8_t l_offset = io_data.size();
+             io_data.resize(l_offset + 1 + l_vpdSize);
+ 
+-            //Add on the data to the type/length byte indicating it is binary
+-            io_data.at(l_offset) = l_vpdSize;
++            //Add on the data to the type/length byte indicating it is ascii
++            // otherwise leave it as binary
++            if (i_ascii)
++            {
++                io_data.at(l_offset) = l_vpdSize
++                                       + IPMIFRUINV::TYPELENGTH_BYTE_ASCII;
++            }
++            else
++            {
++                io_data.at(l_offset) = l_vpdSize;
++            }
++            l_offset += 1;
+ 
+             //Read the VPD data directly into fru inventory data buffer
+-            l_errl = deviceRead(iv_target,&io_data[l_offset+1], l_vpdSize,
+-                        DEVICE_SPD_ADDRESS(i_keyword));
++            l_errl = deviceRead(iv_target,&io_data[l_offset], l_vpdSize,
++                       DEVICE_SPD_ADDRESS(i_keyword));
+         }
+         else
+         {
+@@ -534,10 +545,10 @@ errlHndl_t procIpmiFruInv::buildBoardInfoArea(std::vector<uint8_t> &io_data)
+         l_errl = addVpdData(io_data, MVPD::VINI, MVPD::DR, true);
+         if (l_errl) { break; }
+         //Set Board Info serial number
+-        l_errl = addVpdData(io_data, MVPD::VINI, MVPD::SN);
++        l_errl = addVpdData(io_data, MVPD::VRML, MVPD::SN, true);
+         if (l_errl) { break; }
+         //Set Board part number
+-        l_errl = addVpdData(io_data, MVPD::VINI, MVPD::FN);
++        l_errl = addVpdData(io_data, MVPD::VRML, MVPD::PN, true);
+         if (l_errl) { break; }
+         //Set Board FRU File ID
+         l_errl = addVpdData(io_data, MVPD::VINI, MVPD::VZ);
+@@ -760,47 +771,18 @@ errlHndl_t backplaneIpmiFruInv::buildBoardInfoArea(
+ 
+         //Set Product Name - ascii formatted data
+         //@fixme RTC Story 118373
+-        l_errl = addVpdData(io_data, CVPD::OSYS, CVPD::DR, true);
+-
+-        //Support Legacy VPD without OSYS record
+-        if (l_errl)
+-        {
+-
+-            TRACFCOMP(g_trac_ipmi,
+-                      "backplaneIpmiFruInv::buildChassisBoardInfoArea - "
+-                      " Using Legacy Chassis VPD Data without OSYS record");
+-
+-            //Delete errorlog and use Legacy VPD Fields
+-            delete l_errl;
+-            l_errl = NULL;
+-            //Set Product Name - ascii formatted data
+-            //@fixme RTC Story 118373
+-            l_errl = addVpdData(io_data, CVPD::OPFR, CVPD::DR, true);
+-            if (l_errl) { break; }
+-
+-            //Set Product Serial number - ascii formatted data
+-            //@fixme RTC Story 118373
+-            l_errl = addVpdData(io_data, CVPD::OPFR, CVPD::VS, true);
+-            if (l_errl) { break; }
+-
+-            //Set Product Part number - ascii formatted data
+-            //@fixme RTC Story 118373
+-            l_errl = addVpdData(io_data, CVPD::OPFR, CVPD::VP, true);
+-            if (l_errl) { break; }
++        l_errl = addVpdData(io_data, CVPD::OPFR, CVPD::DR, true);
++        if (l_errl) { break; }
+ 
+-        }
+-        else
+-        {
+-            //Set serial number - ascii formatted field
+-            //@fixme RTC Story 118373
+-            l_errl = addVpdData(io_data, CVPD::OSYS, CVPD::SS, true);
+-            if (l_errl) { break; }
++        //Set Product Serial number - ascii formatted data
++        //@fixme RTC Story 118373
++        l_errl = addVpdData(io_data, CVPD::OPFR, CVPD::VS, true);
++        if (l_errl) { break; }
+ 
+-            //Set chassis part number - ascii formatted field
+-            //@fixme RTC Story 118373
+-            l_errl = addVpdData(io_data, CVPD::OSYS, CVPD::MM, true);
+-            if (l_errl) { break; }
+-        }
++        //Set Product Part number - ascii formatted data
++        //@fixme RTC Story 118373
++        l_errl = addVpdData(io_data, CVPD::OPFR, CVPD::VP, true);
++        if (l_errl) { break; }
+ 
+         //Push Fru File ID Byte - NULL
+         io_data.push_back(IPMIFRUINV::TYPELENGTH_BYTE_NULL);
+@@ -950,22 +932,19 @@ void IpmiFruInv::addEcidData(const TARGETING::TargetHandle_t& i_target,
+ {
+     // Create Custom ECID Field
+     // - First put in 'ECID:' to make it obvious what this is
+-    uint8_t l_data[] = {IPMIFRUINV::TYPELENGTH_BYTE_ASCII + 5,'E','C','I','D',
+-                                   ':', IPMIFRUINV::TYPELENGTH_BYTE_NULL + 16};
++    uint8_t l_data[] = {IPMIFRUINV::TYPELENGTH_BYTE_ASCII + 21,'E','C','I','D',
++                                    ':'};
+ 
+     // @todo-RTC:124687 - Refactor multiple reallocations
+     io_data.insert( io_data.end(),
+                     &l_data[0],
+                     &l_data[0] + (uint8_t(sizeof(l_data) / sizeof(uint8_t))));
+ 
+-    uint8_t* l_vDataPtr = (uint8_t*) &i_ecidInfo[0];
+-    //Insert first 64 bits of ECID data
+-    io_data.insert(io_data.end(),
+-                &l_vDataPtr[0], &l_vDataPtr[0]+8);
+-    l_vDataPtr = (uint8_t*) &i_ecidInfo[1];
+-    //Insert second 64 bits of ECID data
+-    io_data.insert(io_data.end(),
+-        &l_vDataPtr[0], &l_vDataPtr[0]+8);
++    char l_ecidAscii[33];
++    sprintf(l_ecidAscii, "%.16llX%.16llX", i_ecidInfo[0], i_ecidInfo[1]);
++
++    uint8_t* l_vDataPtr = (uint8_t*) &l_ecidAscii[0];
++    io_data.insert(io_data.end(), &l_vDataPtr[0], &l_vDataPtr[0]+16);
+ 
+     return;
+ }
+diff --git a/src/usr/ipmi/ipmifruinvprvt.H b/src/usr/ipmi/ipmifruinvprvt.H
+index aed5dfc..2573a84 100644
+--- a/src/usr/ipmi/ipmifruinvprvt.H
++++ b/src/usr/ipmi/ipmifruinvprvt.H
+@@ -303,9 +303,11 @@ class isdimmIpmiFruInv : public IpmiFruInv
+      *        record
+      * @param[in/out] data, The container with record data
+      * @param[in] keyword, Indicates where in the VPD to get more data
+-
++     * @param[in] ascii, Indicates if VPD field is in ascii format or not
+      */
+-    errlHndl_t addVpdData(std::vector<uint8_t> &io_data, uint8_t i_keyword);
++    errlHndl_t addVpdData(std::vector<uint8_t> &io_data,
++                          uint8_t i_keyword,
++                          bool i_ascii=false);
+ 
+ };
+ 
+-- 
+1.8.2.2
+

--- a/openpower/package/hostboot/hostboot-0015-Add-PNOR-Version-Information-to-IPMI-Fru-Inventory.patch
+++ b/openpower/package/hostboot/hostboot-0015-Add-PNOR-Version-Information-to-IPMI-Fru-Inventory.patch
@@ -1,0 +1,351 @@
+From 5bda70dc5e135261f5393858959056b44332885b Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Mon, 30 Mar 2015 15:11:28 -0500
+Subject: [PATCH 6/7] Add PNOR Version Information to IPMI Fru Inventory
+
+Change-Id: Ib49fe67e9c6631b2b7ea0005e692c9aea6d84057
+RTC:123353
+(cherry picked from commit 90f8e938932e867283e28cade6741b6bf968602c)
+---
+ src/usr/ipmi/ipmifruinv.C                          | 207 +++++++++++++++++++++
+ src/usr/ipmi/ipmifruinvprvt.H                      |  47 +++++
+ .../targeting/common/xmltohb/attribute_types.xml   |   8 +
+ src/usr/targeting/common/xmltohb/target_types.xml  |   1 +
+ 4 files changed, 263 insertions(+)
+
+diff --git a/src/usr/ipmi/ipmifruinv.C b/src/usr/ipmi/ipmifruinv.C
+index c6c7a30..b376ebf 100644
+--- a/src/usr/ipmi/ipmifruinv.C
++++ b/src/usr/ipmi/ipmifruinv.C
+@@ -36,6 +36,7 @@
+ #include "ipmifru.H"
+ #include "ipmifruinvprvt.H"
+ #include <stdio.h>
++#include <pnor/pnorif.H>
+ 
+ extern trace_desc_t * g_trac_ipmi;
+ 
+@@ -83,6 +84,10 @@ IpmiFruInv *IpmiFruInv::Factory(TARGETING::TargetHandleList i_targets,
+             // @todo-RTC:117702
+             l_fru = new backplaneIpmiFruInv(l_target, i_targets, i_updateData);
+             break;
++        case TARGETING::TYPE_SYS:
++            // Use sys target for setting System Firmware Info
++            l_fru = new systemFwIpmiFruInv(l_target);
++            break;
+         default:
+             assert(false,
+                 "IpmiFruInv::Factory: No support for target type given: [%08x]",
+@@ -926,6 +931,199 @@ errlHndl_t backplaneIpmiFruInv::addVpdData(std::vector<uint8_t> &io_data,
+     return l_errl;
+ }
+ 
++//##############################################################################
++systemFwIpmiFruInv::systemFwIpmiFruInv( TARGETING::TargetHandle_t i_target )
++    :IpmiFruInv(i_target)
++{
++
++};
++
++errlHndl_t systemFwIpmiFruInv::buildInternalUseArea(std::vector<uint8_t>
++                                                                       &io_data)
++{
++    //This section not needed for proc type
++    return IpmiFruInv::buildEmptyArea(io_data);
++}
++
++errlHndl_t systemFwIpmiFruInv::buildChassisInfoArea(std::vector<uint8_t>
++                                                                       &io_data)
++{
++    //This section not needed for system firmware type
++    return IpmiFruInv::buildEmptyArea(io_data);
++}
++
++errlHndl_t systemFwIpmiFruInv::buildBoardInfoArea(std::vector<uint8_t> &io_data)
++{
++    //This section not needed for system firmware type
++    return IpmiFruInv::buildEmptyArea(io_data);
++}
++
++errlHndl_t systemFwIpmiFruInv::buildProductInfoArea(std::vector<uint8_t>
++                                                                       &io_data)
++{
++    errlHndl_t l_errl = NULL;
++
++    do {
++        //Set formatting data that goes at the beginning of the record
++        preFormatProcessing(io_data, true);
++
++        uint8_t l_data[] = {IPMIFRUINV::TYPELENGTH_BYTE_ASCII + 3,'I','B','M',
++                            IPMIFRUINV::TYPELENGTH_BYTE_ASCII + 18, 'O','p','e',
++                            'n','P','O','W','E','R',' ','F','i','r','m','w','a',
++                            'r','e', IPMIFRUINV::TYPELENGTH_BYTE_NULL};
++
++        io_data.insert( io_data.end(),
++                    &l_data[0],
++                    &l_data[0] + (uint8_t(sizeof(l_data) / sizeof(uint8_t))));
++
++        //Get PNOR Version Here
++        PNOR::SectionInfo_t l_pnorInfo;
++        l_errl = getSectionInfo( PNOR::VERSION , l_pnorInfo);
++        if (l_errl) { break; }
++
++        uint8_t* l_versionData = reinterpret_cast<uint8_t*>( l_pnorInfo.vaddr );
++        //Total Bytes in PNOR Version String
++        uint8_t l_numBytes = 0;
++        uint8_t l_curOffset = 0;
++
++        //Total Number of fields needed to print PNOR Version String
++        uint8_t l_numFields = 0;
++        bool l_clearStandardFields = true;
++
++        //First determine number of bytes in PNOR Version string
++        //  with the caveat there is a max record size allowed, so
++        //  the string will be cut off if too long
++        //Also, remove whitespace/newline chars
++        while ((l_numBytes < IPMIFRUINV::MAX_RECORD_SIZE -
++                              (uint8_t(sizeof(l_data) / sizeof(uint8_t))) -
++                              IPMIFRUINV::COMMON_HEADER_FORMAT_SIZE - 8)
++                               && (((char)(l_versionData[l_numBytes])) != '\0'))
++        {
++
++            if (((char)(l_versionData[l_numBytes])) == '\n')
++            {
++
++                if (l_numBytes > l_curOffset)
++                {
++                    //Add on size of this field to the data buffer
++                    io_data.push_back(
++                         IPMIFRUINV::TYPELENGTH_BYTE_ASCII
++                           + (l_numBytes-l_curOffset));
++
++                    io_data.insert(io_data.end(),
++                       &l_versionData[0]+(l_curOffset),
++                       &l_versionData[0]+(l_numBytes));
++                }
++
++                //Null data for standard fields needs to be indicated once after
++                // the first segment of data is displayed to match the
++                // ipmi fru spec
++                if (l_clearStandardFields)
++                {
++                    //Add Empty Asset Tag
++                    io_data.push_back(uint8_t(0));
++                    //FRU File ID - Empty
++                    io_data.push_back(IPMIFRUINV::TYPELENGTH_BYTE_NULL);
++                    io_data.push_back(uint8_t(0)); // Empty FRU File ID bytes
++                    l_clearStandardFields = false;
++                }
++
++                //Increment past the newline char
++                l_curOffset = l_numBytes + 1;
++            }
++            l_numBytes++;
++        }
++
++        if (l_curOffset == 0)
++        {
++            //Calculate the number of fields required to display this data
++            //  given only MAX_ASCII_FIELD_SIZE bytes can be in any one given
++            //  IPMI fru inventory field
++            l_numFields = l_numBytes / IPMIFRUINV::MAX_ASCII_FIELD_SIZE;
++            if (l_numBytes % IPMIFRUINV::MAX_ASCII_FIELD_SIZE)
++            {
++                l_numFields += 1;
++            }
++
++            //Count by number of fields, adding the data to the buffer as
++            // we go.
++            for (uint8_t i=0; i < l_numFields; i++)
++            {
++                //Determine the data size for this particular field
++                uint8_t l_dataSize=IPMIFRUINV::MAX_ASCII_FIELD_SIZE;
++                if (i == l_numFields - 1)
++                {
++                    l_dataSize = l_numBytes -
++                           (i * IPMIFRUINV::MAX_ASCII_FIELD_SIZE);
++                }
++
++                //Add on size of this field to the data buffer
++                io_data.push_back(IPMIFRUINV::TYPELENGTH_BYTE_ASCII
++                                         + l_dataSize);
++
++                //Insert this segment of version string data
++                io_data.insert(io_data.end(),
++                       &l_versionData[0]+(i * IPMIFRUINV::MAX_ASCII_FIELD_SIZE),
++                       &l_versionData[0]+(i * IPMIFRUINV::MAX_ASCII_FIELD_SIZE)
++                                        +l_dataSize);
++
++                //Null data for standard fields needs to be indicated once after
++                // the first segment of data is displayed to match the
++                // ipmi fru spec
++                if (l_clearStandardFields)
++                {
++                    //Add Empty Asset Tag
++                    io_data.push_back(uint8_t(0));
++                    //FRU File ID - Empty
++                    io_data.push_back(IPMIFRUINV::TYPELENGTH_BYTE_NULL);
++                    //io_data.push_back(uint8_t(0)); // Empty FRU File ID bytes
++                    l_clearStandardFields = false;
++                }
++
++            }
++        }
++        else
++        {
++            if (l_numBytes > l_curOffset)
++            {
++                io_data.push_back( IPMIFRUINV::TYPELENGTH_BYTE_ASCII
++                        + (l_numBytes-l_curOffset));
++
++                io_data.insert(io_data.end(),
++                       &l_versionData[0]+(l_curOffset),
++                       &l_versionData[0]+(l_numBytes));
++            }
++
++        }
++
++        if (l_clearStandardFields)
++        {
++            //Add Asset Tag
++            io_data.push_back(uint8_t(0)); //No Asset Tag needed - O bytes
++            //FRU File ID - Empty
++            io_data.push_back(IPMIFRUINV::TYPELENGTH_BYTE_NULL);
++            //io_data.push_back(uint8_t(0)); // Empty FRU File ID bytes
++        }
++
++        io_data.push_back(IPMIFRUINV::END_OF_CUSTOM_FIELDS);
++
++        //Finalize section formatting
++        postFormatProcessing(io_data);
++
++    } while(0);
++
++    return l_errl;
++}
++
++errlHndl_t systemFwIpmiFruInv::buildMultiRecordInfoArea(std::vector<uint8_t>
++                                                                       &io_data)
++{
++    //This section not needed for system firmware type
++    return IpmiFruInv::buildEmptyArea(io_data);
++}
++
++
++
+ void IpmiFruInv::addEcidData(const TARGETING::TargetHandle_t& i_target,
+                              const TARGETING::ATTR_ECID_type& i_ecidInfo,
+                              std::vector<uint8_t> &io_data)
+@@ -993,6 +1191,15 @@ void IPMIFRUINV::setData(bool i_updateData)
+             IPMIFRUINV::gatherClearData(pSys, frusToClear);
+         }
+ 
++        //Get System FW FRU_ID if available
++        uint32_t l_systemFwFruId;
++        bool hasSystemFwFruId =
++                            pSys->tryGetAttr<TARGETING::ATTR_BMC_FRU_ID>(l_systemFwFruId);
++        if (hasSystemFwFruId)
++        {
++            l_potentialFrus.push_back(std::make_pair(pSys, l_systemFwFruId));
++        }
++
+         // Find list of all target types that may need a fru inv. record set
+         IPMIFRUINV::gatherSetData(pSys, frusToClear,
+                                      l_potentialFrus, i_updateData);
+diff --git a/src/usr/ipmi/ipmifruinvprvt.H b/src/usr/ipmi/ipmifruinvprvt.H
+index 2573a84..468a47f 100644
+--- a/src/usr/ipmi/ipmifruinvprvt.H
++++ b/src/usr/ipmi/ipmifruinvprvt.H
+@@ -42,6 +42,8 @@ namespace IPMIFRUINV
+         COMMON_HEADER_FORMAT_SIZE     = 8, //size in bytes
+         DEFAULT_CHASSIS_TYPE          = 0x05,
+         DEFAULT_FRU_OFFSET            = 0,
++        MAX_ASCII_FIELD_SIZE          = 0x3F, //size in bytes
++        MAX_RECORD_SIZE               = 0xFF, //size in bytes
+     };
+ };
+ 
+@@ -460,4 +462,49 @@ class backplaneIpmiFruInv : public IpmiFruInv
+ 
+ };
+ 
++//Child class for building up System Firwmare Fru Inventory Record Data
++class systemFwIpmiFruInv : public IpmiFruInv
++{
++
++  public:
++    /**
++    * @brief Constructor
++    *
++    * @param[in] TargetHandle_t, Handle to target for which
++    *             to get relevant IPMI FRU Data from
++    */
++    systemFwIpmiFruInv( TARGETING::TargetHandle_t i_target);
++
++    /**
++     * @brief Builds the Internal Use Area Data Section
++     * @param[in/out] data, The container to put internal use area data in
++     */
++    errlHndl_t buildInternalUseArea(std::vector<uint8_t> &io_data);
++
++    /**
++     * @brief Builds the Chassis Info Area Data Section
++     * @param[in/out] data, The container to put chassis info area data in
++     */
++    errlHndl_t buildChassisInfoArea(std::vector<uint8_t> &io_data);
++
++    /**
++     * @brief Builds the Board Info Area Data Section
++     * @param[in/out] data, The container to put board info area data in
++     */
++    errlHndl_t buildBoardInfoArea(std::vector<uint8_t> &io_data);
++
++    /**
++     * @brief Builds the Product Info Area Data Section
++     * @param[in/out] data, The container to put product info area data in
++     */
++    errlHndl_t buildProductInfoArea(std::vector<uint8_t> &io_data);
++
++    /**
++     * @brief Builds the MultiRecord Info Area Data Section
++     * @param[in/out] data, The container to put multirecord info area data in
++     */
++    errlHndl_t buildMultiRecordInfoArea(std::vector<uint8_t> &io_data);
++
++};
++
+ #endif
+diff --git a/src/usr/targeting/common/xmltohb/attribute_types.xml b/src/usr/targeting/common/xmltohb/attribute_types.xml
+index c961ebe..bbf02dd 100644
+--- a/src/usr/targeting/common/xmltohb/attribute_types.xml
++++ b/src/usr/targeting/common/xmltohb/attribute_types.xml
+@@ -11425,6 +11425,14 @@ firmware notes: Platforms should initialize this attribute to AUTO (0)</descript
+ </attribute>
+ 
+ <attribute>
++    <id>BMC_FRU_ID</id>
++    <description>BMC FRU ID attribute for node class</description>
++    <simpleType><uint32_t><default>0</default></uint32_t></simpleType>
++    <persistency>non-volatile</persistency>
++    <readable/>
++</attribute>
++
++<attribute>
+     <id>PLCK_IPL_ATTR_OVERRIDES_EXIST</id>
+     <description>
+       Set to 1 by HWSV to indicate that attribute overrides exist in a PLCK IPL
+diff --git a/src/usr/targeting/common/xmltohb/target_types.xml b/src/usr/targeting/common/xmltohb/target_types.xml
+index 6dc4e58..b4b9a30 100644
+--- a/src/usr/targeting/common/xmltohb/target_types.xml
++++ b/src/usr/targeting/common/xmltohb/target_types.xml
+@@ -305,6 +305,7 @@
+     <attribute><id>MNFG_TH_CEN_L4_CACHE_CES</id></attribute>
+     <attribute><id>OPT_MEMMAP_GROUP_POLICY</id></attribute>
+     <attribute><id>FRU_ID</id></attribute>
++    <attribute><id>BMC_FRU_ID</id></attribute>
+ </targetType>
+ 
+ <targetType>
+-- 
+1.8.2.2
+

--- a/openpower/package/palmetto-xml/palmetto-xml-0001-Revert-Merge-pull-request-12-from-open-power-bofferd.patch
+++ b/openpower/package/palmetto-xml/palmetto-xml-0001-Revert-Merge-pull-request-12-from-open-power-bofferd.patch
@@ -1,0 +1,84 @@
+From 55eae8d646b3c95df32b67ef8d67887581f94fa0 Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Tue, 31 Mar 2015 08:15:06 -0500
+Subject: [PATCH] Revert "Merge pull request #12 from
+ open-power/bofferdn-pal-loadline"
+
+This reverts commit dbe13549a81c15c81e1fbd2d3de80ea91dd20503, reversing
+changes made to 167ded68387aa69fabb28e6cafaa6ae4bf165a40.
+
+Conflicts:
+	palmetto.xml
+---
+ palmetto.xml | 48 ++++++++++++++++++++++++------------------------
+ 1 file changed, 24 insertions(+), 24 deletions(-)
+
+diff --git a/palmetto.xml b/palmetto.xml
+index 6df6652..89669ab 100644
+--- a/palmetto.xml
++++ b/palmetto.xml
+@@ -2854,6 +2854,30 @@
+ 		<default>1</default>
+ 	</attribute>
+ 	<attribute>
++		<id>PROC_R_DISTLOSS_VCS</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_R_DISTLOSS_VDD</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_R_LOADLINE_VCS</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_R_LOADLINE_VDD</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_VRM_VOFFSET_VCS</id>
++		<default></default>
++	</attribute>
++	<attribute>
++		<id>PROC_VRM_VOFFSET_VDD</id>
++		<default></default>
++	</attribute>
++	<attribute>
+ 		<id>PROC_X_BUS_WIDTH</id>
+ 		<default>2</default>
+ 	</attribute>
+@@ -3735,30 +3759,6 @@
+ 		<default>0</default>
+ 	</attribute>
+ 	<attribute>
+-		<id>PROC_R_DISTLOSS_VCS</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_R_DISTLOSS_VDD</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_R_LOADLINE_VCS</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_R_LOADLINE_VDD</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_VRM_VOFFSET_VCS</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+-		<id>PROC_VRM_VOFFSET_VDD</id>
+-		<default></default>
+-	</attribute>
+-	<attribute>
+ 		<id>PSI_BRIDGE_BASE_ADDR</id>
+ 		<default>0,0x0000000000000000</default>
+ 	</attribute>
+-- 
+1.8.2.2
+

--- a/openpower/package/palmetto-xml/palmetto-xml-0002-Add-Sys-Fw-Fru-Id.patch
+++ b/openpower/package/palmetto-xml/palmetto-xml-0002-Add-Sys-Fw-Fru-Id.patch
@@ -1,0 +1,27 @@
+From 3856cbf0c35a5ed0d983717150efbe446324713d Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Tue, 31 Mar 2015 08:17:17 -0500
+Subject: [PATCH 2/2] Add Sys Fw Fru Id
+
+---
+ palmetto.xml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/palmetto.xml b/palmetto.xml
+index 89669ab..8f32666 100644
+--- a/palmetto.xml
++++ b/palmetto.xml
+@@ -2554,6 +2554,10 @@
+ 		<default></default>
+ 	</attribute>
+ 	<attribute>
++	        <id>BMC_FRU_ID</id>
++	        <default>15</default>
++	</attribute>
++	<attribute>
+ 		<id>FRU_NAME</id>
+ 		<default></default>
+ 	</attribute>
+-- 
+1.8.2.2
+

--- a/openpower/package/palmetto-xml/palmetto-xml.mk
+++ b/openpower/package/palmetto-xml/palmetto-xml.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PALMETTO_XML_VERSION = 167ded68387aa69fabb28e6cafaa6ae4bf165a40
+PALMETTO_XML_VERSION = 9206323e35e40ca8957049965ba8e2564467040e
 PALMETTO_XML_SITE = $(call github,open-power,palmetto-xml,$(PALMETTO_XML_VERSION))
 
 PALMETTO_XML_LICENSE = Apache-2.0


### PR DESCRIPTION
Hostboot Changes Included:

Iaa9c4e00325f8fa6efb7a9fca1275bcea2759308  -- Opal System info from OSYS
Id251307aa76259d8a290a92d9e9f3418b181bc3e -- SBE Update fix for new AMI level
I378e0763c5ca8c13830d0e6c057b24e6beb5dc8c -- Fix for AMI Sel causing power off in istep 6.5
If8f08d1602b4437aa0e72e6d2e8d99ca615a2c77 -- Limit Binary Trace cap at 64 bytes
Iaa4802e72e355acd03cb88e58c40d1069dd76ef5 -- FRU Inventory / VPD Mapping Update
Ib49fe67e9c6631b2b7ea0005e692c9aea6d84057 -- FRU Inventory PNOR Version Update
I245cd9947d5b7a05ff9a8f92ff18c658b1fe09d6 -- Support Partial Good Xbus

Habanero XML Changes:
Bring up to latest commit level: 4173b205b0a7dfd18a97f3a0d5319c9aad893035 with a patch to revert an XML change that didn't work with the given level of HB. Also included is an XML patch to include the System Software IPMI Fru Inventory ID.

Palmetto XML Changes:
Bring up to latest commit level: 9206323e35e40ca8957049965ba8e2564467040e with a patch to revert an XML change that didn't work with the given level of HB. Also included is an XML patch to include the System Software IPMI Fru Inventory ID.

