### PR TITLE
Add ability to force all subpackage version strings to be generated

### DIFF
--- a/openpower/package/VERSION.readme
+++ b/openpower/package/VERSION.readme
@@ -13,11 +13,17 @@
 
     ## Op-build Commands ##
 
-    # Display package version
+    # Display subpackage version
     op-build $(package)-version
 
-    # Force a rebuild of a package version
+    # Display entire pnor version
+    op-build openpower-pnor-version
+
+    # Force a rebuild of a subpackage version
     op-build $(package)-build-version
+
+    # Force a rebuild of all subpackage versions
+    op-build openpower-pnor-build-version-all
 
     ##  Version String (ASCII) ##
 

--- a/openpower/package/pkg-versions.mk
+++ b/openpower/package/pkg-versions.mk
@@ -184,9 +184,15 @@ $(1)-print-version:
 		@cat $$($$(UPPER_CASE_PKG)_VERSION_FILE)
 		@echo ""; echo "**See openpower/package/VERSION.readme for detailed info on package strings"; echo ""
 
-
 # Rule to generate pnor version
 $(1)-build-version: $$(foreach pkg,$$(OPENPOWER_VERSIONED_SUBPACKAGES), $$(pkg)-version)
+		@$$($$(UPPER_CASE_PKG)_OPENPOWER_VERSION_FILE)
+		@echo "=== $$(UPPER_CASE_PKG)_VERSION ==="
+		@cat $$($$(UPPER_CASE_PKG)_VERSION_FILE)
+		@echo ""; echo "**See openpower/package/VERSION.readme for detailed info on package strings"; echo ""
+
+# Rule to force re-generation of all versioned subpackages
+$(1)-build-version-all: $$(foreach pkg,$$(OPENPOWER_VERSIONED_SUBPACKAGES), $$(pkg)-build-version)
 		@$$($$(UPPER_CASE_PKG)_OPENPOWER_VERSION_FILE)
 		@echo "=== $$(UPPER_CASE_PKG)_VERSION ==="
 		@cat $$($$(UPPER_CASE_PKG)_VERSION_FILE)


### PR DESCRIPTION
Originally openpower-pnor-version would only end up rebuilding
subpackages that don't have a version file, even if outdated.