### PR TITLE
Update skiboot to skiboot-5.0 release (rather than -rc3)

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.0-rc3
+SKIBOOT_VERSION = skiboot-5.0
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

It should be noted that master has commits that master-next doesn't.