### PR TITLE
Update hostboot, hostboot binaries and openpower-pnor packages

### DIFF
--- a/openpower/configs/firestone_defconfig
+++ b/openpower/configs/firestone_defconfig
@@ -8,6 +8,7 @@ BR2_HOSTBOOT_CONFIG_FILE="firestone.config"
 
 BR2_HOSTBOOT_BINARY_SBE_FILENAME="venice_sbe.img.ecc"
 BR2_HOSTBOOT_BINARY_SBEC_FILENAME="centaur_sbec_pad.img.ecc"
+BR2_HOSTBOOT_BINARY_WINK_FILENAME="p8.ref_image.hdr.bin.ecc"
 
 BR2_OCC_BIN_FILENAME="occ.bin"
 

--- a/openpower/configs/habanero_defconfig
+++ b/openpower/configs/habanero_defconfig
@@ -8,6 +8,7 @@ BR2_HOSTBOOT_CONFIG_FILE="habanero.config"
 
 BR2_HOSTBOOT_BINARY_SBE_FILENAME="venice_sbe.img.ecc"
 BR2_HOSTBOOT_BINARY_SBEC_FILENAME="centaur_sbec_pad.img.ecc"
+BR2_HOSTBOOT_BINARY_WINK_FILENAME="p8.ref_image.hdr.bin.ecc"
 
 BR2_OCC_BIN_FILENAME="occ.bin"
 

--- a/openpower/configs/palmetto_defconfig
+++ b/openpower/configs/palmetto_defconfig
@@ -8,6 +8,7 @@ BR2_HOSTBOOT_CONFIG_FILE="palmetto.config"
 
 BR2_HOSTBOOT_BINARY_SBE_FILENAME="venice_sbe.img.ecc"
 BR2_HOSTBOOT_BINARY_SBEC_FILENAME="centaur_sbec_pad.img.ecc"
+BR2_HOSTBOOT_BINARY_WINK_FILENAME="p8.ref_image.hdr.bin.ecc"
 
 BR2_OCC_BIN_FILENAME="occ.bin"
 

--- a/openpower/package/hostboot-binaries/hostboot_binaries.mk
+++ b/openpower/package/hostboot-binaries/hostboot_binaries.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HOSTBOOT_BINARIES_VERSION ?= d41753f2b5e2510d6bc6ce58adf8e55207b8d317
+HOSTBOOT_BINARIES_VERSION ?= 22470e51b6342f9c307e28b3ea7cdb194ff954d4
 HOSTBOOT_BINARIES_SITE ?= $(call github,open-power,hostboot-binaries,$(HOSTBOOT_BINARIES_VERSION))
 HOSTBOOT_BINARIES_LICENSE = Apache-2.0
 
@@ -13,7 +13,7 @@ HOSTBOOT_BINARIES_INSTALL_TARGET = NO
 
 define HOSTBOOT_BINARIES_INSTALL_IMAGES_CMDS
      $(INSTALL) -D $(@D)/cvpd.bin  $(STAGING_DIR)/hostboot_binaries/cvpd.bin
-     $(INSTALL) -D $(@D)/p8.ref_image.hdr.bin.ecc  $(STAGING_DIR)/hostboot_binaries/p8.ref_image.hdr.bin.ecc
+     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_WINK_FILENAME) $(STAGING_DIR)/hostboot_binaries/
      $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) $(STAGING_DIR)/hostboot_binaries/
      $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_SBE_FILENAME)  $(STAGING_DIR)/hostboot_binaries/
 endef

--- a/openpower/package/hostboot/hostboot.mk
+++ b/openpower/package/hostboot/hostboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HOSTBOOT_VERSION ?= 70b5e31d74487d51e69a0e0a390adea6b4f32dc5
+HOSTBOOT_VERSION ?= c646754e720b5cd21534425ca90bb414a4a3ff12
 HOSTBOOT_SITE ?= $(call github,open-power,hostboot,$(HOSTBOOT_VERSION))
 
 HOSTBOOT_LICENSE = Apache-2.0

--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -46,6 +46,11 @@ config BR2_HOSTBOOT_BINARY_SBEC_FILENAME
         help
             String used to define name of sbec hostboot binary file
 
+config BR2_HOSTBOOT_BINARY_WINK_FILENAME
+        string "Name of winkle hostboot binary"
+        help
+            String used to define name of winkle hostboot binary file
+
 config BR2_OPENPOWER_TARGETING_BIN_FILENAME
         string "Name of openpower binary targeting file"
         help

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -8,7 +8,7 @@
 # make doesn't care for quotes in the dependencies.
 XML_PACKAGE=$(subst $\",,$(BR2_OPENPOWER_XML_PACKAGE))
 
-OPENPOWER_PNOR_VERSION ?= 3748ff041448a3909d5ffc5e62befcfcb597c0c1
+OPENPOWER_PNOR_VERSION ?= ed1682e10526ebd85825427fbf397361bb0e34aa
 OPENPOWER_PNOR_SITE ?= $(call github,open-power,pnor,$(OPENPOWER_PNOR_VERSION))
 
 OPENPOWER_PNOR_LICENSE = Apache-2.0
@@ -48,6 +48,7 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -targeting_binary_source $(BR2_OPENPOWER_TARGETING_BIN_FILENAME) \
             -sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME) \
             -sbec_binary_filename $(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) \
+            -wink_binary_filename $(BR2_HOSTBOOT_BINARY_WINK_FILENAME) \
             -occ_binary_filename $(OCC_STAGING_DIR)/$(BR2_OCC_BIN_FILENAME) \
             -capp_binary_filename $(BINARIES_DIR)/$(BR2_CAPP_UCODE_BIN_FILENAME) \
             -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE)
@@ -63,6 +64,7 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -bootkernel $(BINARIES_DIR)/$(LINUX_IMAGE_NAME) \
             -sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME) \
             -sbec_binary_filename $(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) \
+            -wink_binary_filename $(BR2_HOSTBOOT_BINARY_WINK_FILENAME) \
             -occ_binary_filename $(OCC_STAGING_DIR)/$(BR2_OCC_BIN_FILENAME) \
             -targeting_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME) \
             -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE)


### PR DESCRIPTION
This updates 3 packages.

Hostboot moves up to https://github.com/open-power/hostboot/commit/c646754e720b5cd21534425ca90bb414a4a3ff12

Hostboot-binaries moves up to https://github.com/open-power/hostboot-binaries/commit/22470e51b6342f9c307e28b3ea7cdb194ff954d4

Openpower-pnor moves up to https://github.com/open-power/pnor/commit/ed1682e10526ebd85825427fbf397361bb0e34aa

There are changes to all defconfig files to support the new parameter in update_image.pl and create_pnor_image.pl (addition of a variable defined winkle file name)