### PR TITLE
OCC fixes for Tyan Issue 134 and other miscellaneous fixes

### DIFF
--- a/openpower/package/occ/occ.mk
+++ b/openpower/package/occ/occ.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCC_VERSION ?= 19678d6a7dd078e3206bac6f1d5e3cf03008542b
+OCC_VERSION ?= db9b6efae0555cbc4df2200e0e8a18e4a4c4477c
 OCC_SITE ?= $(call github,open-power,occ,$(OCC_VERSION))
 OCC_LICENSE = Apache-2.0
 OCC_DEPENDENCIES = host-binutils host-p8-pore-binutils


### PR DESCRIPTION
This OCC code drop has:
- Fixes for Issue#134
- Fix for incorrect socket power on call-home data
- Use correct slot for call-home log
- Support for 'Thermal Throttle' and 'Quick Power Drop' bits in the poll response