### PR TITLE
Increase UART timeout to 10s

### DIFF
--- a/openpower/package/hostboot/hostboot-0001-Increase-uart-delay.patch
+++ b/openpower/package/hostboot/hostboot-0001-Increase-uart-delay.patch
@@ -18,7 +18,7 @@ index 385a05c..a269168 100644
              {
                  const uint64_t DELAY_NS = 100;
 -                const uint64_t DELAY_LOOPS = 10000;
-+                const uint64_t DELAY_LOOPS = 1000000;
++                const uint64_t DELAY_LOOPS = 100000000;
  
                  uint8_t data = 0;
                  uint64_t loops = 0;


### PR DESCRIPTION
Up UART timeout to 10s to compensate for loaded BMC during auto boot