### PR TITLE
Bump skiboot to skiboot-5.0.3

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.0.2
+SKIBOOT_VERSION = skiboot-5.0.3
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
Just one fix in 5.0.3 vs 5.0.2

    core/mem_region: Create reservations of type REGION_HW_RESERVED

    This fixes an issue where the PRD daemon cannot find reserved ranges
    (eg, the homer image) that have been created by skiboot itself.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>