### PR TITLE
add missing build dependencies to Ubuntu instructions

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,7 @@ Building on *64-bit* Ubuntu/Debian systems
 1. Install Ubuntu 14.04 or Debian 7.5 64-bit.
 2. Install the packages necessary for the build:
 > sudo apt-get install cscope ctags libz-dev libexpat-dev \
+  python language-pack-en \
   build-essential g++ git bison flex unzip \
   libxml-simple-perl libxml-sax-perl libxml2-dev libxml2-utils xsltproc
 3. Continue with the clone, environment setup, and build as noted above.


### PR DESCRIPTION
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

Found by attempting op-build inside a debootstrapped vivid docker container on ppc64el.