### PR TITLE
Firestone OCC fixes for full frequency range on slave OCCs

### DIFF
--- a/openpower/package/occ/occ.mk
+++ b/openpower/package/occ/occ.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCC_VERSION ?= db9b6efae0555cbc4df2200e0e8a18e4a4c4477c
+OCC_VERSION ?= ee27bc9b95dc3090662e46712364fe816ca84a74
 OCC_SITE ?= $(call github,open-power,occ,$(OCC_VERSION))
 OCC_LICENSE = Apache-2.0
 OCC_DEPENDENCIES = host-binutils host-p8-pore-binutils


### PR DESCRIPTION
Relevant changes on this OCC code drop:
- Fix for redundant master role
- Firestone fix for allowing full frequency range on slave OCCs