### PR TITLE
Bump skiboot to skiboot-5.0.4

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.0.3
+SKIBOOT_VERSION = skiboot-5.0.4
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
Release notes are as follows:
Generic
-------
- cpu: fix hang in opal_reinit_cpus()
  A bug introduced in 87690bd19dbb (skiboot-5.0) mean that if a host OS
  was calling opal_reinit_cpus() with offline threads (e.g. kdump with
  SMT!=8 on POWER8), we could, instead of kdumping, hang forever.

  A side effect of this fix is that it is not possible to have a kdump
  kernel be a different endian than the host kernel.
- Correctly set the Relative Priority Register
  This means that on boot, the RPR will be set to a known value (the
  same as phyp). This register controls the relative priority of each
  thread in a core.
  Previously, we were leaving it to whatever HostBoot set it to, which
  may not be the desired value.

astbmc systems
--------------
- enable prd_init() for Firestone platform
- fix bug in hw/bt.c that would dereference an invalid address, likely
  causing a checkstop.
- ipmi/sel: fix use after free

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>