### PR TITLE
Bump skiboot to skiboot-5.0.5

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.0.4
+SKIBOOT_VERSION = skiboot-5.0.5
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
One commit from 5.0.4:

commit f5a7c43a163f5484d2bd2b8b74814abc23f1e92d

    bt: Remove B_BUSY state

    The bt layer used to cache the value of B_BUSY in the state machine,
    assuming that once B_BUSY was cleared by the BMC that it would never
    be set by the BMC again unless a message was sent to the bt interface.

    This was mostly true for the AMI firmware except when the BMC reboots
    which causes B_BUSY to be set. There may also be additional
    circumstances which set B_BUSY. Therefore the bt layer must check
    B_BUSY is clear before sending a message making the B_BUSY state
    superfluous.