### PR TITLE
Adding XZ decompression functionality for the skiboot payload

### DIFF
--- a/openpower/configs/firestone_defconfig
+++ b/openpower/configs/firestone_defconfig
@@ -32,6 +32,7 @@ BR2_OPENPOWER_PNOR_UPDATE_FILENAME="firestone_update.pnor"
 # skiboot requirements
 BR2_TARGET_SKIBOOT=y
 BR2_TARGET_SKIBOOT_EMBED_PAYLOAD=n
+BR2_TARGET_SKIBOOT_XZ=n
 
 # petitboot requirements
 BR2_ENABLE_LOCALE_PURGE=y

--- a/openpower/configs/garrison_defconfig
+++ b/openpower/configs/garrison_defconfig
@@ -30,6 +30,7 @@ BR2_OPENPOWER_PNOR_UPDATE_FILENAME="garrison_update.pnor"
 # skiboot requirements
 BR2_TARGET_SKIBOOT=y
 BR2_TARGET_SKIBOOT_EMBED_PAYLOAD=n
+BR2_TARGET_SKIBOOT_XZ=n
 
 # petitboot requirements
 BR2_ENABLE_LOCALE_PURGE=y

--- a/openpower/configs/habanero_defconfig
+++ b/openpower/configs/habanero_defconfig
@@ -32,6 +32,7 @@ BR2_OPENPOWER_PNOR_UPDATE_FILENAME="habanero_update.pnor"
 # skiboot requirements
 BR2_TARGET_SKIBOOT=y
 BR2_TARGET_SKIBOOT_EMBED_PAYLOAD=n
+BR2_TARGET_SKIBOOT_XZ=n
 
 # petitboot requirements
 BR2_ENABLE_LOCALE_PURGE=y

--- a/openpower/configs/palmetto_defconfig
+++ b/openpower/configs/palmetto_defconfig
@@ -31,6 +31,7 @@ BR2_OPENPOWER_PNOR_FILENAME="palmetto.pnor"
 # skiboot requirements
 BR2_TARGET_SKIBOOT=y
 BR2_TARGET_SKIBOOT_EMBED_PAYLOAD=n
+BR2_TARGET_SKIBOOT_XZ=n
 
 # petitboot requirements
 BR2_ENABLE_LOCALE_PURGE=y

--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -35,6 +35,17 @@ config BR2_SKIBOOT_LID_NAME
         help
             String used to define sapphire lid filename
 
+config BR2_TARGET_SKIBOOT_XZ
+        boolean "compress the skiboot image with xz"
+        default n
+
+config BR2_SKIBOOT_LID_XZ_NAME
+        string "Name of compressed skiboot lid name to be used"
+        default "skiboot.lid" if !BR2_TARGET_SKIBOOT_XZ
+        default "skiboot.lid.xz" if BR2_TARGET_SKIBOOT_XZ
+        help
+            String used to define compressed sapphire lid filename
+
 config BR2_HOSTBOOT_BINARY_SBE_FILENAME
         string "Name of sbe hostboot binary"
         help
@@ -60,3 +71,8 @@ config BR2_OPENPOWER_TARGETING_ECC_FILENAME
         string "Name of openpower binary targeting file"
         help
             String used to define name of openpower targeting binary file, ecc protected
+
+config XZ_COMPRESSION_ENABLED
+        string "false if we are not compressing with XZ anywhere"
+        default "false" if !BR2_TARGET_SKIBOOT_XZ
+        default "true" if BR2_TARGET_SKIBOOT_XZ

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -51,7 +51,8 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -wink_binary_filename $(BR2_HOSTBOOT_BINARY_WINK_FILENAME) \
             -occ_binary_filename $(OCC_STAGING_DIR)/$(BR2_OCC_BIN_FILENAME) \
             -capp_binary_filename $(BINARIES_DIR)/$(BR2_CAPP_UCODE_BIN_FILENAME) \
-            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE)
+            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE) \
+            -payload  $(BINARIES_DIR)/$(BR2_SKIBOOT_LID_NAME)
 
         mkdir -p $(STAGING_DIR)/pnor/
         $(TARGET_MAKE_ENV) $(@D)/create_pnor_image.pl \
@@ -60,14 +61,15 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -hb_image_dir $(HOSTBOOT_IMAGE_DIR) \
             -scratch_dir $(OPENPOWER_PNOR_SCRATCH_DIR) \
             -outdir $(STAGING_DIR)/pnor/ \
-            -payload $(BINARIES_DIR)/$(BR2_SKIBOOT_LID_NAME) \
+            -payload $(BINARIES_DIR)/$(BR2_SKIBOOT_LID_XZ_NAME) \
             -bootkernel $(BINARIES_DIR)/$(LINUX_IMAGE_NAME) \
             -sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME) \
             -sbec_binary_filename $(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) \
             -wink_binary_filename $(BR2_HOSTBOOT_BINARY_WINK_FILENAME) \
             -occ_binary_filename $(OCC_STAGING_DIR)/$(BR2_OCC_BIN_FILENAME) \
             -targeting_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME) \
-            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE)
+            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE) \
+            -xz_compression $(XZ_COMPRESSION_ENABLED)
 
         $(INSTALL) $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME) $(BINARIES_DIR)
 


### PR DESCRIPTION
This is the functionality for RTC 125550. Currently, the default is to have the skiboot payload not be decompressed. This is all configured with a config variable. This needs to be merged with two other commits:
1) Hostboot-side: Change-Id Iea8bf169a1e9f81419effe66f147148c68d33131, http://gfw160.aus.stglabs.ibm.com:8080/gerrit/#/c/19457/ 
2) op-pnor pull request with the same comment "Adding XZ decompression functionality for the skiboot payload" https://github.com/open-power/pnor/pull/34