### PR TITLE
bump skiboot to 5.1.0-beta2

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.1.0-beta1
+SKIBOOT_VERSION = skiboot-5.1.0-beta2
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
We'll do the final skiboot release before we tag the next op-build, but this should be really really quite close to what we include then. Pushing here for further testing.