### PR TITLE
Bump skiboot to 5.1.0

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.1.0-beta2
+SKIBOOT_VERSION = skiboot-5.1.0
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
Over skiboot-5.1.0-beta2, we have the following changes:
- opal_prd now supports multiple socket systems
- fix compiler warnings in gard and libflash

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

Fixes https://github.com/open-power/op-build/issues/200