### PR TITLE
skiboot-5.1.1

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.1.0
+SKIBOOT_VERSION = skiboot-5.1.1
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
fixes build issues where HOSTCC is old (RHEL6)
fixes one CAPI bug (fault wasn't escalated to a fence)

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

https://github.com/open-power/op-build/issues/200 and https://github.com/open-power/op-build/issues/238