### PR TITLE
OCC Firmware Update for Garrison

### DIFF
--- a/openpower/package/occ/occ.mk
+++ b/openpower/package/occ/occ.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCC_VERSION ?= 0726e692d4eea5465f0509bb9f12185745a77ca9
+OCC_VERSION ?= 94276061f084a3dcad0d6cb8877799706fdebed1
 OCC_SITE ?= $(call github,open-power,occ,$(OCC_VERSION))
 OCC_LICENSE = Apache-2.0
 OCC_DEPENDENCIES = host-binutils host-p8-pore-binutils


### PR DESCRIPTION
Changes to OCC build

- enable Call home in observation mode
- OCC Firmware support for Garrison
