### PR TITLE
Use linux-rebuild-with-initramfs rather than linux26

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -17,7 +17,7 @@ OPENPOWER_PNOR_DEPENDENCIES = hostboot hostboot-binaries $(XML_PACKAGE) skiboot 
 ifeq ($(BR2_TARGET_SKIBOOT_EMBED_PAYLOAD),n)
 
 ifeq ($(BR2_TARGET_ROOTFS_INITRAMFS),y)
-OPENPOWER_PNOR_DEPENDENCIES += linux26-rebuild-with-initramfs
+OPENPOWER_PNOR_DEPENDENCIES += linux-rebuild-with-initramfs
 else
 OPENPOWER_PNOR_DEPENDENCIES += linux
 endif

--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -18,7 +18,7 @@ ifeq ($(BR2_TARGET_SKIBOOT_EMBED_PAYLOAD),y)
 SKIBOOT_MAKE_OPTS += KERNEL="$(BINARIES_DIR)/$(LINUX_IMAGE_NAME)"
 
 ifeq ($(BR2_TARGET_ROOTFS_INITRAMFS),y)
-SKIBOOT_DEPENDENCIES += linux26-rebuild-with-initramfs
+SKIBOOT_DEPENDENCIES += linux-rebuild-with-initramfs
 else
 SKIBOOT_DEPENDENCIES += linux
 endif


### PR DESCRIPTION
In future buildroot versions, the linux26 targets don't exist.

Currently, the buildroot we use for op-build supports both.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>