### PR TITLE
Bump skiboot to 5.1.3

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SKIBOOT_VERSION = skiboot-5.1.2
+SKIBOOT_VERSION = skiboot-5.1.3
 SKIBOOT_SITE = $(call github,open-power,skiboot,$(SKIBOOT_VERSION))
 SKIBOOT_INSTALL_IMAGES = YES
 SKIBOOT_INSTALL_TARGET = NO


### PR DESCRIPTION
Over skiboot-5.1.2, we have the following changes:

- slot names for firestone platform
- fix display of LPC errors
- SBE based timer support
  - on supported platforms limits reliance on Linux heartbeat
- fix use-after-free in fsp/ipmi
- fix hang on TOD/TB errors (time-of-day/timebase) on OpenPower systems
  - On getting a Hypervizor Maintenance Interrupt to get the timebase
    back into a running state, we would call prlog which would use
    the LPC UART console driver on OpenPower systems, which depends on
    a working timebase, leading to a hang.
    We now don't depend on a working timebase in this recovery codepath.
- enable prd for garrison platform
- PCI: Clear error bits after changing MPS
  Chaning MPS on PCI upstream bridge might cause error bits set on
  downstream endpoints when system boots into Linux as below case
  shows:
  host# lspci -vvs 0001:06:00.0
  0001:06:00.0 Ethernet controller: Broadcom Corporation \
               NetXtreme II BCM57810 10 Gigabit Ethernet (rev 10)
  DevSta:	CorrErr+ UncorrErr- FatalErr- UnsuppReq+ AuxPwr- TransPend-
  CESta:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- NonFatalErr+

  This clears those error bits in AER and PCIe capability after MPS
  is changed. With the patch applied, no more error bits are seen.