### PR TITLE
Remove dependency on realpath in post-build rootfs setup.

### DIFF
--- a/openpower/scripts/fixup-target-var
+++ b/openpower/scripts/fixup-target-var
@@ -5,8 +5,7 @@
 find $TARGET_DIR/var/ -type l |
 while read path
 do
-    target=$(realpath $path)
-    [ -d "$target" ] || continue
-    rm $path
-    mkdir $path
+    [ -d "$path" ] || continue
+    rm -v $path
+    mkdir -v $path
 done


### PR DESCRIPTION
Ran into problems on other build systems where the post-build rootfs fix-up script was failing to run when "realpath" was not available. It should not be necessary to perform the desired check anyway.
A secondary issue, not addressed here, is that the build did not detect the failure.