### PR TITLE
OCC firmware update for Firestone

### DIFF
--- a/openpower/package/occ/occ.mk
+++ b/openpower/package/occ/occ.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCC_VERSION ?= 0362706b9b9eac5af36ba5b41c5d93a108ccd90d
+OCC_VERSION ?= bf4d8cbd05414fd2d297ec7e9381c2f77940a743
 OCC_SITE ?= $(call github,open-power,occ,$(OCC_VERSION))
 OCC_LICENSE = Apache-2.0
 OCC_DEPENDENCIES = host-binutils host-p8-pore-binutils


### PR DESCRIPTION
-Skip unnecessary firdata collection for EX targets