### PR TITLE
Bump buildroot to 2015.08.1

### DIFF
--- a/openpower/device_table.txt
+++ b/openpower/device_table.txt
@@ -7,17 +7,15 @@
 #
 # <name>				<type>	<mode>	<uid>	<gid>	<major>	<minor>	<start>	<inc>	<count>
 /dev					d	755	0	0	-	-	-	-	-
+/tmp					d	1777	0	0	-	-	-	-	-
 /etc					d	755	0	0	-	-	-	-	-
 /root					d	700	0	0	-	-	-	-	-
 /var/www				d	755	33	33	-	-	-	-	-
-/etc/random-seed			f	600	0	0	-	-	-	-	-
 /etc/shadow				f	600	0	0	-	-	-	-	-
 /etc/passwd				f	644	0	0	-	-	-	-	-
 /etc/network/if-up.d			d	755	0	0	-	-	-	-	-
 /etc/network/if-pre-up.d		d	755	0	0	-	-	-	-	-
-/etc/network/if-post-up.d		d	755	0	0	-	-	-	-	-
 /etc/network/if-down.d			d	755	0	0	-	-	-	-	-
-/etc/network/if-pre-down.d		d	755	0	0	-	-	-	-	-
 /etc/network/if-post-down.d		d	755	0	0	-	-	-	-	-
 # uncomment this to allow starting x as non-root
 #/usr/X11R6/bin/Xfbdev		     	f	4755	0	0	-	-	-	-	-


### PR DESCRIPTION
In the process, sync our openpower/device_table.txt with upstream
buildroot.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

See https://github.com/open-power/buildroot/pull/15 for details of what changed in buildroot.