### PR TITLE
Enable IPL-time Checkstop analysis for Palmetto, Habanero, and Firestone

### DIFF
--- a/openpower/configs/hostboot/firestone.config
+++ b/openpower/configs/hostboot/firestone.config
@@ -56,6 +56,7 @@ set BMC_BT_LPC_IPMI
 
 # Enable Checktop Analysis
 set ENABLE_CHECKSTOP_ANALYSIS
+set IPLTIME_CHECKSTOP_ANALYSIS
 
 # Hostboot will detect hardware changes
 set HOST_HCDB_SUPPORT

--- a/openpower/configs/hostboot/garrison.config
+++ b/openpower/configs/hostboot/garrison.config
@@ -53,6 +53,7 @@ set BMC_BT_LPC_IPMI
 
 # Enable Checktop Analysis
 set ENABLE_CHECKSTOP_ANALYSIS
+set IPLTIME_CHECKSTOP_ANALYSIS
 
 # Hostboot will detect hardware changes
 set HOST_HCDB_SUPPORT

--- a/openpower/configs/hostboot/habanero.config
+++ b/openpower/configs/hostboot/habanero.config
@@ -59,6 +59,7 @@ set BMC_BT_LPC_IPMI
 
 # Enable Checktop Analysis
 set ENABLE_CHECKSTOP_ANALYSIS
+set IPLTIME_CHECKSTOP_ANALYSIS
 
 # Hostboot will detect hardware changes
 set HOST_HCDB_SUPPORT

--- a/openpower/configs/hostboot/palmetto.config
+++ b/openpower/configs/hostboot/palmetto.config
@@ -55,6 +55,7 @@ set BMC_BT_LPC_IPMI
 
 # Enable Checktop Analysis
 set ENABLE_CHECKSTOP_ANALYSIS
+set IPLTIME_CHECKSTOP_ANALYSIS
 
 # Hostboot will detect hardware changes
 set HOST_HCDB_SUPPORT

--- a/openpower/package/occ/occ.mk
+++ b/openpower/package/occ/occ.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCC_VERSION ?= 1d5035ddc6787d0d192dfb1d65f580e779db49f6
+OCC_VERSION ?= 1093bf945e6c22650ca0b83da2347ee7d21cbe41
 OCC_SITE ?= $(call github,open-power,occ,$(OCC_VERSION))
 OCC_LICENSE = Apache-2.0
 OCC_DEPENDENCIES = host-binutils host-p8-pore-binutils


### PR DESCRIPTION
-Set config flag IPLTIME_CHECKSTOP_ANALYSIS