### PR TITLE
Allow for building behind at HTTP(S) proxy

### DIFF
--- a/openpower/package/capp-ucode/capp-ucode.mk
+++ b/openpower/package/capp-ucode/capp-ucode.mk
@@ -5,7 +5,7 @@
 ################################################################################
 CAPP_UCODE_VERSION ?= 105cb8f69edb7e76c4d153bf2e5c9718811a3114
 CAPP_UCODE_SITE ?= $(call github,open-power,capp-ucode,$(CAPP_UCODE_VERSION))
-PETITBOOT_LICENSE = Apache-2.0
+CAPP_UCODE_LICENSE = Apache-2.0
 
 CAPP_UCODE_INSTALL_IMAGES = YES
 

--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 PETITBOOT_VERSION = d171258160f7ed4756531f51e66fb116753bc990
-PETITBOOT_SITE = git://github.com/open-power/petitboot.git
+PETITBOOT_SITE ?= $(call github,open-power,petitboot,$(PETITBOOT_VERSION))
 PETITBOOT_DEPENDENCIES = ncurses udev host-bison host-flex lvm2
 PETITBOOT_LICENSE = GPLv2
 PETITBOOT_LICENSE_FILES = COPYING


### PR DESCRIPTION
This patch allows op-build to execute without a direct Internet connection.