### PR TITLE
Set option to expand aliases

### DIFF
--- a/op-build-env
+++ b/op-build-env
@@ -8,4 +8,5 @@ fi
 export BR2_EXTERNAL=${__PWD}/openpower
 export BR2_DL_DIR=${__PWD}/dl
 
+shopt -s expand_aliases
 alias op-build="make --directory=${__PWD}/buildroot O=${__PWD}/output "


### PR DESCRIPTION
This `shopt` command allows the `op-build` alias to be expanded in non-interactive bash shells. I added this to my fork to allow easier build automation through Jenkins.