### PR TITLE
Shell function instead of alias for op-build

### DIFF
--- a/op-build-env
+++ b/op-build-env
@@ -8,5 +8,6 @@ fi
 export BR2_EXTERNAL=${__PWD}/openpower
 export BR2_DL_DIR=${__PWD}/dl
 
-shopt -s expand_aliases
-alias op-build="make --directory=${__PWD}/buildroot O=${__PWD}/output "
+op-build () {
+    make --directory=${__PWD}/buildroot O=${__PWD}/output $@
+}

--- a/op-build-env
+++ b/op-build-env
@@ -8,4 +8,5 @@ fi
 export BR2_EXTERNAL=${__PWD}/openpower
 export BR2_DL_DIR=${__PWD}/dl
 
+shopt -s expand_aliases
 alias op-build="make --directory=${__PWD}/buildroot O=${__PWD}/output "


### PR DESCRIPTION
This is in response to the comments shared on PR #363 . It should skip the need for the `shopt` call and work for `/bin/sh` and non-interactive bash shells

@stewart-ibm @williamspatrick @jazurin how do you guys feel about this instead?