### PR TITLE
Update Garrison Config 

### DIFF
--- a/openpower/configs/hostboot/garrison.config
+++ b/openpower/configs/hostboot/garrison.config
@@ -29,8 +29,8 @@ unset CDIMM_FORMAT_FOR_CVPD
 set GPIODD
 set PALMETTO_VDDR
 
-# disable sbe updates
-set NO_SBE_UPDATES
+# Enable SBE updates
+set SBE_UPDATE_INDEPENDENT
 
 unset PCIE_HOTPLUG_CONTROLLER
 
@@ -55,7 +55,9 @@ set BMC_BT_LPC_IPMI
 
 # Enable Checktop Analysis
 set ENABLE_CHECKSTOP_ANALYSIS
-set IPLTIME_CHECKSTOP_ANALYSIS
+# Turn off IPLTIME_CHECKSTOP_ANALYSIS for now until memory issue can be solved.
+# Seems to only be an issue for lager ddr4 configs.
+#set IPLTIME_CHECKSTOP_ANALYSIS
 
 # Hostboot will detect hardware changes
 set HOST_HCDB_SUPPORT


### PR DESCRIPTION
This commit turns on the SBE updates, and turns off the IPLTIME_CHECKSTOP_ANALYSIS config.
When the IPLTIME_CHECKSTOP_ANALYSIS config is on larger ddr4 garrison systems fail to IPL with an out of memory condition. Turning off this config is a workaround that will allow all machines to boot while this issue is root caused.