### PR TITLE
Turn on IPLTIME_CHECKSTOP_ANALYSIS for Garrison

### DIFF
--- a/openpower/configs/hostboot/garrison.config
+++ b/openpower/configs/hostboot/garrison.config
@@ -55,9 +55,7 @@ set BMC_BT_LPC_IPMI
 
 # Enable Checktop Analysis
 set ENABLE_CHECKSTOP_ANALYSIS
-# Turn off IPLTIME_CHECKSTOP_ANALYSIS for now until memory issue can be solved.
-# Seems to only be an issue for lager ddr4 configs.
-#set IPLTIME_CHECKSTOP_ANALYSIS
+set IPLTIME_CHECKSTOP_ANALYSIS
 
 # Hostboot will detect hardware changes
 set HOST_HCDB_SUPPORT


### PR DESCRIPTION
I have tested this on a large memory configuration machine in Rochester, and it appears we have gained back enough memory to boot up.

I wanted to test this with Jay's new memory tool, but it doesn't sound like that will capture memory consumption at every istep yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/410)
<!-- Reviewable:end -->
