### PR TITLE
openpower-pnor: revert to working version

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -8,7 +8,7 @@
 # make doesn't care for quotes in the dependencies.
 XML_PACKAGE=$(subst $\",,$(BR2_OPENPOWER_XML_PACKAGE))
 
-OPENPOWER_PNOR_VERSION ?= f5b523fb0a7fe312c5d011e9853f53c22a2f2262
+OPENPOWER_PNOR_VERSION ?= 1e4410052a26acf4b439226860afae9507f0d94a
 OPENPOWER_PNOR_SITE ?= $(call github,open-power,pnor,$(OPENPOWER_PNOR_VERSION))
 
 OPENPOWER_PNOR_LICENSE = Apache-2.0


### PR DESCRIPTION
Without corresponding updates to makefiles (not yet approved for merge),
the newer openpower-pnor package breaks building a pnor with an error
from xz.

Fixes: 1d0a7b00d7578aafa8c8a0a81925e501453a01f1
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/421)
<!-- Reviewable:end -->
