### PR TITLE
petitboot: depend on BR2_PACKAGE_LVM2 for devicemapper explicitly

### DIFF
--- a/openpower/package/petitboot/Config.in
+++ b/openpower/package/petitboot/Config.in
@@ -2,6 +2,7 @@ config BR2_PACKAGE_PETITBOOT
 	bool "petitboot"
 	# petitboot needs udev /dev management
 	depends on BR2_PACKAGE_HAS_UDEV
+	select BR2_PACKAGE_LVM2
 	select BR2_PACKAGE_NCURSES
 	select BR2_PACKAGE_NCURSES_TARGET_PANEL
 	select BR2_PACKAGE_NCURSES_TARGET_FORM


### PR DESCRIPTION
Previously, we added dependency to petitboot.mk but we were missing
it from Config.in, which buildroot 2016.02 errors out on.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/423)
<!-- Reviewable:end -->
