### PR TITLE
Adding XZ decompression functionality for skiboot

### DIFF
--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -33,7 +33,18 @@ config BR2_SKIBOOT_LID_NAME
         string "Name of skiboot lid name to be used"
         default "skiboot.lid"
         help
-            String used to define sapphire lid filename
+            String used to define skiboot lid filename
+
+config BR2_TARGET_SKIBOOT_XZ
+        boolean "Compress the skiboot image with XZ"
+        default n
+
+config BR2_SKIBOOT_LID_XZ_NAME
+        string "Name of compressed skiboot lid"
+        default "skiboot.lid" if !BR2_TARGET_SKIBOOT_XZ
+        default "skiboot.lid.xz" if BR2_TARGET_SKIBOOT_XZ
+        help
+            String used to define compressed skiboot lid filename
 
 config BR2_HOSTBOOT_BINARY_SBE_FILENAME
         string "Name of sbe hostboot binary"
@@ -60,3 +71,8 @@ config BR2_OPENPOWER_TARGETING_ECC_FILENAME
         string "Name of openpower binary targeting file"
         help
             String used to define name of openpower targeting binary file, ecc protected
+
+config BR2_OPENPOWER_PNOR_XZ_ENABLED
+        string "False if we are not compressing with XZ anywhere"
+        default "false" if !BR2_TARGET_SKIBOOT_XZ
+        default "true" if BR2_TARGET_SKIBOOT_XZ

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -24,6 +24,11 @@ endif
 
 endif
 
+ifeq ($(BR2_OPENPOWER_PNOR_XZ_ENABLED),y)
+OPENPOWER_PNOR_DEPENDENCIES += host_xz
+endif
+
+
 OPENPOWER_PNOR_INSTALL_IMAGES = YES
 OPENPOWER_PNOR_INSTALL_TARGET = NO
 
@@ -51,7 +56,8 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -wink_binary_filename $(BR2_HOSTBOOT_BINARY_WINK_FILENAME) \
             -occ_binary_filename $(OCC_STAGING_DIR)/$(BR2_OCC_BIN_FILENAME) \
             -capp_binary_filename $(BINARIES_DIR)/$(BR2_CAPP_UCODE_BIN_FILENAME) \
-            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE)
+            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE) \
+            -payload $(BINARIES_DIR)/$(BR2_SKIBOOT_LID_NAME)
 
         mkdir -p $(STAGING_DIR)/pnor/
         $(TARGET_MAKE_ENV) $(@D)/create_pnor_image.pl \
@@ -60,14 +66,15 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -hb_image_dir $(HOSTBOOT_IMAGE_DIR) \
             -scratch_dir $(OPENPOWER_PNOR_SCRATCH_DIR) \
             -outdir $(STAGING_DIR)/pnor/ \
-            -payload $(BINARIES_DIR)/$(BR2_SKIBOOT_LID_NAME) \
+            -payload $(BINARIES_DIR)/$(BR2_SKIBOOT_LID_XZ_NAME) \
             -bootkernel $(BINARIES_DIR)/$(LINUX_IMAGE_NAME) \
             -sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME) \
             -sbec_binary_filename $(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) \
             -wink_binary_filename $(BR2_HOSTBOOT_BINARY_WINK_FILENAME) \
             -occ_binary_filename $(OCC_STAGING_DIR)/$(BR2_OCC_BIN_FILENAME) \
             -targeting_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME) \
-            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE)
+            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE) \
+            -xz_compression $(BR2_OPENPOWER_PNOR_XZ_ENABLED)
 
         $(INSTALL) $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME) $(BINARIES_DIR)
 


### PR DESCRIPTION
We have already merged hostboot and open-power/pnor changes, this is the final change for RTC:125550.

This change will allow a user the option to XZ compress the skiboot image. The BR2_TARGET_SKIBOOT_XZ config will need to be enabled for the specific configuration, and then the skiboot image will be compressed. This change is only for compressing and decompressing the skiboot image section. If another section needs compression, we would have to enable decompression inside hostboot for that specific section, and make additional pnor changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/424)
<!-- Reviewable:end -->
