### PR TITLE
petitboot: Create default log directory

### DIFF
--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -67,6 +67,8 @@ define PETITBOOT_POST_INSTALL
 	ln -sf /usr/sbin/pb-udhcpc \
 		$(TARGET_DIR)/usr/share/udhcpc/default.script.d/
 
+	mkdir -p $(TARGET_DIR)/var/log/petitboot
+
 	$(MAKE) -C $(@D)/po DESTDIR=$(TARGET_DIR) install
 endef
 


### PR DESCRIPTION
With recent changes to Skiroot the petitboot-nc processes can start
before the pb-discover server. In this case /var/log/petitboot hasn't
been created by S15pb-discover yet, and each interface will fail to
fopen() its respective log file. This means each petitboot-nc process
will not produce logs the first time it is run.

Create the directory at build time to make sure we always get UI logs.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/442)
<!-- Reviewable:end -->
