### PR TITLE
New kernel and nvme fixes

### DIFF
--- a/openpower/linux/linux-0001-xhci-Use-xhci_pci_remove-for-xhci-device-shutdown.patch
+++ b/openpower/linux/linux-0001-xhci-Use-xhci_pci_remove-for-xhci-device-shutdown.patch
@@ -1,4 +1,4 @@
-From 3f099329a4aa747c3cccb502bb3a671df6e76cfd Mon Sep 17 00:00:00 2001
+From b9b3f9efd871e228ae14a8adbd7ef4b7d4a46123 Mon Sep 17 00:00:00 2001
 From: Thadeu Lima De Souza Cascardo <thadeul@br.ibm.com>
 Date: Tue, 25 Mar 2014 10:45:16 -0400
 Subject: [PATCH 1/7] xhci: Use xhci_pci_remove for xhci device shutdown
@@ -23,5 +23,5 @@ index c2d65206ec6c..c2d33e274542 100644
  	.driver = {
  		.pm = &usb_hcd_pci_pm_ops
 -- 
-2.7.3
+2.7.4
 

--- a/openpower/linux/linux-0002-Revert-usb-xhci-stop-everything-on-the-first-call-to.patch
+++ b/openpower/linux/linux-0002-Revert-usb-xhci-stop-everything-on-the-first-call-to.patch
@@ -1,4 +1,4 @@
-From 797d3fde5250abb4dedf00536282b8f93e4b66fe Mon Sep 17 00:00:00 2001
+From c761f38475875d0840be302ad64904a18353e332 Mon Sep 17 00:00:00 2001
 From: Joel Stanley <joel@jms.id.au>
 Date: Thu, 28 Jan 2016 13:07:06 +1030
 Subject: [PATCH 2/7] Revert "usb: xhci: stop everything on the first call to
@@ -58,5 +58,5 @@ index 776d59c32bc5..cef80e930db9 100644
  	 * (xhci_stop() could be called as part of failed init).
  	 */
 -- 
-2.7.3
+2.7.4
 

--- a/openpower/linux/linux-0003-xhci-do-not-halt-the-secondary-HCD.patch
+++ b/openpower/linux/linux-0003-xhci-do-not-halt-the-secondary-HCD.patch
@@ -1,4 +1,4 @@
-From 05ac3b2476dd66ba26622d437c2517dd3ac389f1 Mon Sep 17 00:00:00 2001
+From be0312b5d7ccb3becc42a6f483c68765d4567f4c Mon Sep 17 00:00:00 2001
 From: Thadeu Lima de Souza Cascardo <cascardo@linux.vnet.ibm.com>
 Date: Mon, 10 Mar 2014 13:02:13 -0300
 Subject: [PATCH 3/7] xhci: do not halt the secondary HCD
@@ -38,5 +38,5 @@ index cef80e930db9..90f48eb32d93 100644
  }
  
 -- 
-2.7.3
+2.7.4
 

--- a/openpower/linux/linux-0004-drivers-drm-ast-Switch-SCU-to-VGA-output-on-POST.patch
+++ b/openpower/linux/linux-0004-drivers-drm-ast-Switch-SCU-to-VGA-output-on-POST.patch
@@ -1,4 +1,4 @@
-From c12cb7a8c9c8d780ff454399bf4bbbffdd3941f4 Mon Sep 17 00:00:00 2001
+From 36e277c2d85a35348c651ff18e115c70f310368e Mon Sep 17 00:00:00 2001
 From: Jeremy Kerr <jk@ozlabs.org>
 Date: Wed, 2 Mar 2016 11:25:47 +0800
 Subject: [PATCH 4/7] drivers/drm/ast: Switch SCU to VGA output on POST
@@ -68,5 +68,5 @@ index 810c51d92b99..703dba2ba84b 100644
 +	ast_moutdwm(ast, scu_addr | 0x2c, val);
 +}
 -- 
-2.7.3
+2.7.4
 

--- a/openpower/linux/linux-0005-scsi-ignore-errors-from-scsi_dh_add_device.patch
+++ b/openpower/linux/linux-0005-scsi-ignore-errors-from-scsi_dh_add_device.patch
@@ -1,4 +1,4 @@
-From 9d3559f97bd5183d4f84bbef3ea445a2ef841080 Mon Sep 17 00:00:00 2001
+From 2e2cc02d46a147b3386ac67b25d6bb4339afb00e Mon Sep 17 00:00:00 2001
 From: Hannes Reinecke <hare@suse.de>
 Date: Tue, 1 Mar 2016 13:57:59 +1100
 Subject: [PATCH 5/7] scsi: ignore errors from scsi_dh_add_device()
@@ -38,5 +38,5 @@ index c8115b4fe474..750df9b9b11c 100644
  	device_enable_async_suspend(&sdev->sdev_dev);
  	error = device_add(&sdev->sdev_dev);
 -- 
-2.7.3
+2.7.4
 

--- a/openpower/linux/linux-0006-net-mlx4_core-Set-UAR-page-size-to-4KB-regardless-of.patch
+++ b/openpower/linux/linux-0006-net-mlx4_core-Set-UAR-page-size-to-4KB-regardless-of.patch
@@ -1,4 +1,4 @@
-From 50d6158618c001b19967ab48aa9e25b2885b3374 Mon Sep 17 00:00:00 2001
+From 822aa6730a539993c3b17e151b49af6f90dc80e3 Mon Sep 17 00:00:00 2001
 From: Huy Nguyen <huyn@mellanox.com>
 Date: Wed, 17 Feb 2016 17:24:26 +0200
 Subject: [PATCH 6/7] net/mlx4_core: Set UAR page size to 4KB regardless of
@@ -295,5 +295,5 @@ index d3133be12d92..8bab38f8872a 100644
 +}
  #endif /* MLX4_DEVICE_H */
 -- 
-2.7.3
+2.7.4
 

--- a/openpower/linux/linux-0007-Release-4.4.8-openpower1.patch
+++ b/openpower/linux/linux-0007-Release-4.4.8-openpower1.patch
@@ -1,7 +1,7 @@
-From 67b6cef1f1fe1801bbe015be2bccc5e3d9d32f2a Mon Sep 17 00:00:00 2001
+From 1a760bf8893312c55a31323ce3d28e316bef2be3 Mon Sep 17 00:00:00 2001
 From: Joel Stanley <joel@jms.id.au>
-Date: Tue, 20 Oct 2015 15:01:06 +1030
-Subject: [PATCH 7/7] Release 4.4.6-openpower1
+Date: Thu, 14 Apr 2016 21:40:26 +0930
+Subject: [PATCH 7/7] Release 4.4.8-openpower1
 
 Signed-off-by: Joel Stanley <joel@jms.id.au>
 ---
@@ -9,18 +9,18 @@ Signed-off-by: Joel Stanley <joel@jms.id.au>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 87d12b44ab66..9a78974bdab4 100644
+index 1928fcd539cc..48e579df4201 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1,7 +1,7 @@
  VERSION = 4
  PATCHLEVEL = 4
- SUBLEVEL = 6
+ SUBLEVEL = 8
 -EXTRAVERSION =
 +EXTRAVERSION = -openpower1
  NAME = Blurry Fish Butt
  
  # *DOCUMENTATION*
 -- 
-2.7.3
+2.7.4
 


### PR DESCRIPTION
 - Linux 4.4.6 -> 4.4.8 stable release
 - NVMe userspace tool now builds against libudev

Signed-off-by: Joel Stanley <joel@jms.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/449)
<!-- Reviewable:end -->
