### PR TITLE
Source env.bash when running hbDistribute

### DIFF
--- a/openpower/package/hostboot/hostboot.mk
+++ b/openpower/package/hostboot/hostboot.mk
@@ -23,7 +23,7 @@ define HOSTBOOT_BUILD_CMDS
 endef
 
 define HOSTBOOT_INSTALL_IMAGES_CMDS
-        cd $(@D) && $(@D)/src/build/tools/hbDistribute --openpower $(STAGING_DIR)/hostboot_build_images/
+        cd $(@D) && source ./env.bash && $(@D)/src/build/tools/hbDistribute --openpower $(STAGING_DIR)/hostboot_build_images/
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
hbDistrubte will determine if secureboot functionality was compiled
by looking in obj/genfiles/config.h. To simplify getting to that file
we can source env.bash once in the hostboot directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/528)
<!-- Reviewable:end -->
