### PR TITLE
Export PETITBOOT_VERSION to Petitboot autoreconf step

### DIFF
--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -19,6 +19,8 @@ PETITBOOT_CONF_OPTS += --with-ncurses --without-twin-x11 --without-twin-fbdev \
 	      HOST_PROG_SHUTDOWN=/usr/libexec/petitboot/bb-kexec-reboot \
 	      $(if $(BR2_PACKAGE_BUSYBOX),--with-tftp=busybox)
 
+PETITBOOT_AUTORECONF_ENV += PETITBOOT_VERSION=`cat $(PETITBOOT_VERSION_FILE) | cut -d '-' -f 2-`
+
 ifdef PETITBOOT_DEBUG
 PETITBOOT_CONF_OPTS += --enable-debug
 endif

--- a/openpower/package/pkg-versions.mk
+++ b/openpower/package/pkg-versions.mk
@@ -114,7 +114,7 @@ endef ###
 
 # Add appropriate templates to hooks
 $(2)_POST_PATCH_HOOKS += $(2)_OPENPOWER_PATCH_FILE
-$(2)_PRE_BUILD_HOOKS += $(2)_OPENPOWER_VERSION_FILE
+$(2)_PRE_CONFIGURE_HOOKS += $(2)_OPENPOWER_VERSION_FILE
 
 # Top-level rule to print or generate a subpackage version
 $(1)-version: $$(if $$(wildcard $$($(2)_VERSION_FILE)),$(1)-print-version,$(1)-build-version)


### PR DESCRIPTION
This allows us to get the full sha-dirty-patch version string in Petitboot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/532)
<!-- Reviewable:end -->
