### PR TITLE
Wrap double quotes around string comparisons when building package versions

### DIFF
--- a/openpower/package/pkg-versions.mk
+++ b/openpower/package/pkg-versions.mk
@@ -40,7 +40,7 @@ else \
 fi
 
 # If this is for linux, also check openpower/linux
-if [ $(filter "LINUX", "$(2)") == "$(2)" ]; then \
+if [ "$(filter "LINUX", "$(2)")" == "$(2)" ]; then \
 	if ls $$(BR2_EXTERNAL)/$(1)/*.patch 2>/dev/null; then sha512sum \
 		$$(BR2_EXTERNAL)/$(1)/*.patch | sha512sum | \
 		xargs echo >> $$(OPENPOWER_VERSION_DIR)/$(1).tmp_patch.txt; \
@@ -89,7 +89,7 @@ else \
 	sed "s/^\([0-9a-f]\{7\}\).*/\1/;s/$(1)-//;" >> $$($(2)_VERSION_FILE)) \
 	|| echo -n $$($(2)_VERSION) | sed -e 's/$(1)-//' >> $$($(2)_VERSION_FILE); \
 \
-if [ $(filter "LINUX", "$(2)") == "$(2)" ]; then \
+if [ "$(filter "LINUX", "$(2)")" == "$(2)" ]; then \
 	if ls $$(BUILD_DIR)/$(1)-$$($(2)_VERSION)/Makefile 1>/dev/null; then \
 		head $$(BUILD_DIR)/$(1)-$$($(2)_VERSION)/Makefile | grep EXTRAVERSION \
 		| cut -d ' ' -f 3 | \


### PR DESCRIPTION
Fixed `/bin/sh: line 0: [: ==: unary operator expected` 
When doing `op-build $(package)-build-version`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/545)

<!-- Reviewable:end -->
