### PR TITLE
openpower/package: DEPENDENCIES is a list of packages, not targets

### DIFF
--- a/openpower/package/barreleye-xml/barreleye-xml.mk
+++ b/openpower/package/barreleye-xml/barreleye-xml.mk
@@ -8,7 +8,7 @@ BARRELEYE_XML_VERSION ?= 81ac3ff3c4ccd16d2174f455c1cb17976daca948
 BARRELEYE_XML_SITE = $(call github,open-power,barreleye-xml,$(BARRELEYE_XML_VERSION))
 
 BARRELEYE_XML_LICENSE = Apache-2.0
-BARRELEYE_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+BARRELEYE_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 BARRELEYE_XML_INSTALL_IMAGES = YES
 BARRELEYE_XML_INSTALL_TARGET = YES

--- a/openpower/package/firestone-xml/firestone.mk
+++ b/openpower/package/firestone-xml/firestone.mk
@@ -8,7 +8,7 @@ FIRESTONE_XML_VERSION ?= 15e371874a8dec1d8ef279aef2d0a0fed3ded8dd
 FIRESTONE_XML_SITE ?= $(call github,open-power,firestone-xml,$(FIRESTONE_XML_VERSION))
 
 FIRESTONE_XML_LICENSE = Apache-2.0
-FIRESTONE_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+FIRESTONE_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 FIRESTONE_XML_INSTALL_IMAGES = YES
 FIRESTONE_XML_INSTALL_TARGET = YES

--- a/openpower/package/garrison-xml/garrison.mk
+++ b/openpower/package/garrison-xml/garrison.mk
@@ -8,7 +8,7 @@ GARRISON_XML_VERSION ?= b453a813d4c384d9b6d25fa43b84dd6b77f83a82
 GARRISON_XML_SITE ?= $(call github,open-power,garrison-xml,$(GARRISON_XML_VERSION))
 
 GARRISON_XML_LICENSE = Apache-2.0
-GARRISON_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+GARRISON_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 GARRISON_XML_INSTALL_IMAGES = YES
 GARRISON_XML_INSTALL_TARGET = YES

--- a/openpower/package/habanero-xml/habanero-xml.mk
+++ b/openpower/package/habanero-xml/habanero-xml.mk
@@ -8,7 +8,7 @@ HABANERO_XML_VERSION ?= 5565b8fe1feaa4cdb3b296912069c02f46c4cc59
 HABANERO_XML_SITE ?= $(call github,open-power,habanero-xml,$(HABANERO_XML_VERSION))
 
 HABANERO_XML_LICENSE = Apache-2.0
-HABANERO_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+HABANERO_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 HABANERO_XML_INSTALL_IMAGES = YES
 HABANERO_XML_INSTALL_TARGET = YES

--- a/openpower/package/palmetto-xml/palmetto-xml.mk
+++ b/openpower/package/palmetto-xml/palmetto-xml.mk
@@ -8,7 +8,7 @@ PALMETTO_XML_VERSION ?= c6f563966e9fadc4fb60194c064b2310c9b916b1
 PALMETTO_XML_SITE = $(call github,open-power,palmetto-xml,$(PALMETTO_XML_VERSION))
 
 PALMETTO_XML_LICENSE = Apache-2.0
-PALMETTO_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+PALMETTO_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 PALMETTO_XML_INSTALL_IMAGES = YES
 PALMETTO_XML_INSTALL_TARGET = YES

--- a/openpower/scripts/op-target-dependencies
+++ b/openpower/scripts/op-target-dependencies
@@ -56,7 +56,6 @@ sub package_deps
     my $package = shift;
     my $level = shift;
 
-    $package =~ s/-install-images//;    # Strip off -install-images subpass.
     $package =~ s/-rebuild.*//;         # Strip off -rebuild* subpass.
     $package =~ s/linux[0-9]*/linux/;   # Strip off linux version.
 


### PR DESCRIPTION
The current $target-xml packages use target names in their dependencies
lists, where they should be using package names. This breaks certain
targets, like 'legal-info', which create dependencies by adding other
suffixes to the package names.

From the  buildroot manual:

  These dependencies are listed in terms of lower-case package names,
  which can be packages for the target (without the host- prefix) or
  packages for the host (with the host-) prefix). Buildroot will ensure
  that all these packages are built and installed before the current
  package starts its configuration.

This change fixed these DEPENDENCIES defintions to use package names
instead. Consequently, we don't need to filter out the -install-images
target suffix in the op-target-dependencies script.

Fixes #547.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/548)
<!-- Reviewable:end -->
