### PR TITLE
RFC: Fix dependencies for openpower-pnor & xml packages

### DIFF
--- a/openpower/package/Config.in
+++ b/openpower/package/Config.in
@@ -1,6 +1,8 @@
 source "$BR2_EXTERNAL/package/openpower-ffs/Config.in"
 source "$BR2_EXTERNAL/package/hostboot/Config.in"
 source "$BR2_EXTERNAL/package/hostboot-binaries/Config.in"
+source "$BR2_EXTERNAL/package/openpower-mrw/Config.in"
+source "$BR2_EXTERNAL/package/common-p8-xml/Config.in"
 source "$BR2_EXTERNAL/package/palmetto-xml/Config.in"
 source "$BR2_EXTERNAL/package/habanero-xml/Config.in"
 source "$BR2_EXTERNAL/package/firestone-xml/Config.in"

--- a/openpower/package/barreleye-xml/Config.in
+++ b/openpower/package/barreleye-xml/Config.in
@@ -1,6 +1,7 @@
 config BR2_PACKAGE_BARRELEYE_XML
         bool "barreleye_xml"
         default y if (BR2_OPENPOWER_CONFIG_NAME = "barreleye")
+        select BR2_PACKAGE_COMMON_P8_XML
         help
             Utilites for building xml and the targeting binary image
 

--- a/openpower/package/barreleye-xml/barreleye-xml.mk
+++ b/openpower/package/barreleye-xml/barreleye-xml.mk
@@ -8,7 +8,7 @@ BARRELEYE_XML_VERSION ?= 81ac3ff3c4ccd16d2174f455c1cb17976daca948
 BARRELEYE_XML_SITE = $(call github,open-power,barreleye-xml,$(BARRELEYE_XML_VERSION))
 
 BARRELEYE_XML_LICENSE = Apache-2.0
-BARRELEYE_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+BARRELEYE_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 BARRELEYE_XML_INSTALL_IMAGES = YES
 BARRELEYE_XML_INSTALL_TARGET = YES

--- a/openpower/package/common-p8-xml/Config.in
+++ b/openpower/package/common-p8-xml/Config.in
@@ -1,0 +1,4 @@
+config BR2_PACKAGE_COMMON_P8_XML
+        bool "Common P8 XML files"
+        default y if BR2_PACKAGE_HOSTBOOT
+        select BR2_PACKAGE_OPENPOWER_MRW

--- a/openpower/package/firestone-xml/Config.in
+++ b/openpower/package/firestone-xml/Config.in
@@ -1,6 +1,7 @@
 config BR2_PACKAGE_FIRESTONE_XML
         bool "firestone_xml"
         default y if (BR2_OPENPOWER_CONFIG_NAME = "firestone")
+        select BR2_PACKAGE_COMMON_P8_XML
         help
             Utilites for building xml and the targeting binary image
 

--- a/openpower/package/firestone-xml/firestone.mk
+++ b/openpower/package/firestone-xml/firestone.mk
@@ -8,7 +8,7 @@ FIRESTONE_XML_VERSION ?= 783df1f6efce8f0283ca6683825578d1a260cad3
 FIRESTONE_XML_SITE ?= $(call github,open-power,firestone-xml,$(FIRESTONE_XML_VERSION))
 
 FIRESTONE_XML_LICENSE = Apache-2.0
-FIRESTONE_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+FIRESTONE_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 FIRESTONE_XML_INSTALL_IMAGES = YES
 FIRESTONE_XML_INSTALL_TARGET = YES

--- a/openpower/package/garrison-xml/Config.in
+++ b/openpower/package/garrison-xml/Config.in
@@ -1,6 +1,7 @@
 config BR2_PACKAGE_GARRISON_XML
         bool "garrison_xml"
         default y if (BR2_OPENPOWER_CONFIG_NAME = "garrison")
+        select BR2_PACKAGE_COMMON_P8_XML
         help
             Utilites for building xml and the targeting binary image
 

--- a/openpower/package/garrison-xml/garrison.mk
+++ b/openpower/package/garrison-xml/garrison.mk
@@ -8,7 +8,7 @@ GARRISON_XML_VERSION ?= b453a813d4c384d9b6d25fa43b84dd6b77f83a82
 GARRISON_XML_SITE ?= $(call github,open-power,garrison-xml,$(GARRISON_XML_VERSION))
 
 GARRISON_XML_LICENSE = Apache-2.0
-GARRISON_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+GARRISON_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 GARRISON_XML_INSTALL_IMAGES = YES
 GARRISON_XML_INSTALL_TARGET = YES

--- a/openpower/package/habanero-xml/Config.in
+++ b/openpower/package/habanero-xml/Config.in
@@ -1,6 +1,7 @@
 config BR2_PACKAGE_HABANERO_XML
         bool "habanero_xml"
         default y if (BR2_OPENPOWER_CONFIG_NAME = "habanero")
+        select BR2_PACKAGE_COMMON_P8_XML
         help
             Utilites for building xml and the targeting binary image
 

--- a/openpower/package/habanero-xml/habanero-xml.mk
+++ b/openpower/package/habanero-xml/habanero-xml.mk
@@ -8,7 +8,7 @@ HABANERO_XML_VERSION ?= 5565b8fe1feaa4cdb3b296912069c02f46c4cc59
 HABANERO_XML_SITE ?= $(call github,open-power,habanero-xml,$(HABANERO_XML_VERSION))
 
 HABANERO_XML_LICENSE = Apache-2.0
-HABANERO_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+HABANERO_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 HABANERO_XML_INSTALL_IMAGES = YES
 HABANERO_XML_INSTALL_TARGET = YES

--- a/openpower/package/openpower-mrw/Config.in
+++ b/openpower/package/openpower-mrw/Config.in
@@ -1,0 +1,3 @@
+config BR2_PACKAGE_OPENPOWER_MRW
+        bool "Machine Readable Workbook (MRW) infrastructure"
+        default y if BR2_PACKAGE_HOSTBOOT

--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -84,6 +84,5 @@ config BR2_OPENPOWER_TARGETING_ECC_FILENAME
             String used to define name of openpower targeting binary file, ecc protected
 
 config BR2_OPENPOWER_PNOR_XZ_ENABLED
-        string "False if we are not compressing with XZ anywhere"
-        default "false" if !BR2_TARGET_SKIBOOT_XZ
-        default "true" if BR2_TARGET_SKIBOOT_XZ
+        bool "Enable xz compression in PNOR payloads"
+        default y if BR2_TARGET_SKIBOOT_XZ

--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -48,6 +48,7 @@ config BR2_SKIBOOT_LID_NAME
 
 config BR2_TARGET_SKIBOOT_XZ
         boolean "Compress the skiboot image with XZ"
+        select BR2_OPENPOWER_PNOR_XZ_ENABLED
         default y
 
 config BR2_SKIBOOT_LID_XZ_NAME
@@ -85,4 +86,4 @@ config BR2_OPENPOWER_TARGETING_ECC_FILENAME
 
 config BR2_OPENPOWER_PNOR_XZ_ENABLED
         bool "Enable xz compression in PNOR payloads"
-        default y if BR2_TARGET_SKIBOOT_XZ
+        default n

--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -1,6 +1,17 @@
 config BR2_PACKAGE_OPENPOWER_PNOR
         bool "openpower_pnor"
         default y if (BR2_OPENPOWER_PLATFORM && BR2_powerpc_power8)
+        select BR2_PACKAGE_HOSTBOOT
+        select BR2_PACKAGE_HOSTBOOT_BINARIES
+        select BR2_PACKAGE_SKIBOOT
+        select BR2_PACKAGE_OPENPOWER_FFS
+        select BR2_PACKAGE_OCC
+        select BR2_PACKAGE_CAPP_UCODE
+        select BR2_PACKAGE_BARRELEYE_XML if (BR2_OPENPOWER_XML_PACKAGE = "barreleye-xml")
+        select BR2_PACKAGE_FIRESTONE_XML if (BR2_OPENPOWER_XML_PACKAGE = "firestone-xml")
+        select BR2_PACKAGE_GARRISON_XML if (BR2_OPENPOWER_XML_PACKAGE = "garrison-xml")
+        select BR2_PACKAGE_HABANERO_XML if (BR2_OPENPOWER_XML_PACKAGE = "habanero-xml")
+        select BR2_PACKAGE_PALMETTO_XML if (BR2_OPENPOWER_XML_PACKAGE = "palmetto-xml")
         help
             Utilites for building a targeting binary image
 

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -58,7 +58,7 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -capp_binary_filename $(BINARIES_DIR)/$(BR2_CAPP_UCODE_BIN_FILENAME) \
             -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE) \
             -payload $(BINARIES_DIR)/$(BR2_SKIBOOT_LID_NAME) \
-            -xz_compression $(BR2_OPENPOWER_PNOR_XZ_ENABLED)
+            $(if ($(BR2_OPENPOWER_PNOR_XZ_ENABLED),y),-xz_compression true)
 
         mkdir -p $(STAGING_DIR)/pnor/
         $(TARGET_MAKE_ENV) $(@D)/create_pnor_image.pl \

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -25,7 +25,7 @@ endif
 endif
 
 ifeq ($(BR2_OPENPOWER_PNOR_XZ_ENABLED),y)
-OPENPOWER_PNOR_DEPENDENCIES += host_xz
+OPENPOWER_PNOR_DEPENDENCIES += host-xz
 endif
 
 

--- a/openpower/package/palmetto-xml/Config.in
+++ b/openpower/package/palmetto-xml/Config.in
@@ -1,6 +1,7 @@
 config BR2_PACKAGE_PALMETTO_XML
         bool "palmetto_xml"
         default y if (BR2_OPENPOWER_CONFIG_NAME = "palmetto")
+        select BR2_PACKAGE_COMMON_P8_XML
         help
             Utilites for building xml and the targeting binary image
 

--- a/openpower/package/palmetto-xml/palmetto-xml.mk
+++ b/openpower/package/palmetto-xml/palmetto-xml.mk
@@ -8,7 +8,7 @@ PALMETTO_XML_VERSION ?= c6f563966e9fadc4fb60194c064b2310c9b916b1
 PALMETTO_XML_SITE = $(call github,open-power,palmetto-xml,$(PALMETTO_XML_VERSION))
 
 PALMETTO_XML_LICENSE = Apache-2.0
-PALMETTO_XML_DEPENDENCIES = hostboot-install-images openpower-mrw-install-images common-p8-xml-install-images
+PALMETTO_XML_DEPENDENCIES = hostboot openpower-mrw common-p8-xml
 
 PALMETTO_XML_INSTALL_IMAGES = YES
 PALMETTO_XML_INSTALL_TARGET = YES

--- a/openpower/scripts/op-target-dependencies
+++ b/openpower/scripts/op-target-dependencies
@@ -56,7 +56,6 @@ sub package_deps
     my $package = shift;
     my $level = shift;
 
-    $package =~ s/-install-images//;    # Strip off -install-images subpass.
     $package =~ s/-rebuild.*//;         # Strip off -rebuild* subpass.
     $package =~ s/linux[0-9]*/linux/;   # Strip off linux version.
 


### PR DESCRIPTION
Currently, there are a few issues with the dependency & configuration definitions for the PNOR and XML packages. This is preventing us from using some of the non-build targets, like `graph-depends` and `legal-info`, which don't currently work.

This proposed change populates the proper dependency info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/550)
<!-- Reviewable:end -->
