### PR TITLE
petitboot: Update to version v1.2.2

### DIFF
--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PETITBOOT_VERSION = v1.2.1
+PETITBOOT_VERSION = v1.2.2
 PETITBOOT_SITE ?= $(call github,open-power,petitboot,$(PETITBOOT_VERSION))
 PETITBOOT_DEPENDENCIES = ncurses udev host-bison host-flex lvm2
 PETITBOOT_LICENSE = GPLv2
@@ -44,11 +44,11 @@ define PETITBOOT_POST_INSTALL
 	$(INSTALL) -d -m 0755 $(TARGET_DIR)/etc/petitboot/boot.d
 	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/01-create-default-dtb \
 		$(TARGET_DIR)/etc/petitboot/boot.d/
-	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/20-set-stdout \
+	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/30-add-offb \
+		$(TARGET_DIR)/etc/petitboot/boot.d/
+	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/80-set-stdout \
 		$(TARGET_DIR)/etc/petitboot/boot.d/
 	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/90-sort-dtb \
-		$(TARGET_DIR)/etc/petitboot/boot.d/
-	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/30-add-offb \
 		$(TARGET_DIR)/etc/petitboot/boot.d/
 
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL)/package/petitboot/S14silence-console \


### PR DESCRIPTION
Update to v1.2.2 and update the install rule for 80-set-stdout, which
has changed name since the last tagged version.

Fixes https://github.com/open-power/op-build/issues/570

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/573)
<!-- Reviewable:end -->
