### PR TITLE
scripts: Include BTC binary for radeon cards

### DIFF
--- a/openpower/scripts/firenze-firmware-whitelist
+++ b/openpower/scripts/firenze-firmware-whitelist
@@ -17,7 +17,8 @@ whitelist=(     'acenic'
                 'radeon/CAICOS_smc.bin'
                 'radeon/CEDAR_smc.bin'
                 'radeon/CEDAR_me.bin'
-                'radeon/CYPRESS_uvd.bin')
+                'radeon/CYPRESS_uvd.bin'
+                'radeon/BTC_rlc.bin')
 
 if [ -z "${TARGET_DIR}" ] ; then
         echo "TARGET_DIR not defined, setting to $1"


### PR DESCRIPTION
Some radeon chips require an additional _rlc.bin binary that doesn't
match the name of its other required binary files. Include the
BTC_rlc.bin binary as well for CAICOS chips.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/574)
<!-- Reviewable:end -->
