### PR TITLE
Enhancements for op-build ci.

### DIFF
--- a/ci/Dockerfile/fedora23
+++ b/ci/Dockerfile/fedora23
@@ -1,5 +1,6 @@
 FROM fedora:23
-RUN dnf -y install gcc-c++ flex bison git ctags cscope expat-devel patch zlib-devel zlib-static texinfo perl-bignum "perl(XML::Simple)" "perl(YAML)" "perl(XML::SAX)" "perl(Fatal)" "perl(Thread::Queue)" "perl(Env)" "perl(XML::LibXML)" "perl(Digest::SHA1)" libxml2-devel
-RUN dnf -y install which wget unzip tar cpio python bzip2 bc
+RUN dnf -y remove vim-minimal
+RUN dnf -y install gcc-c++ flex bison git ctags cscope expat-devel patch zlib-devel zlib-static texinfo perl-bignum "perl(XML::Simple)" "perl(YAML)" "perl(XML::SAX)" "perl(Fatal)" "perl(Thread::Queue)" "perl(Env)" "perl(XML::LibXML)" "perl(Digest::SHA1)" libxml2-devel libxslt
+RUN dnf -y install which wget unzip tar cpio python bzip2 bc vim redhat-lsb-core
 RUN dnf -y install findutils
 RUN dnf -y install ncurses-devel

--- a/ci/build-all-defconfigs.sh
+++ b/ci/build-all-defconfigs.sh
@@ -3,7 +3,20 @@
 set -ex
 set -eo pipefail
 
-DEFCONFIGS=`(cd openpower/configs; ls -1 *_defconfig)`
+CONFIGTAG="_defconfig"
+
+DEFCONFIGS=();
+
+if [ -z "$2" ]; then
+        echo "Using all the defconfigs for all the platforms"
+        DEFCONFIGS=`(cd openpower/configs; ls -1 *_defconfig)`
+else
+        IFS=', '
+        for p in $2;
+        do
+                DEFCONFIGS+=($p$CONFIGTAG)
+        done
+fi
 
 if [ -z "$1" or ! -d "$1" ]; then
 	echo "No output directory specified"
@@ -17,7 +30,7 @@ fi
 shopt -s expand_aliases
 source op-build-env
 
-for i in $DEFCONFIGS; do
+for i in ${DEFCONFIGS[@]}; do
         op-build $i
         echo 'BR2_CCACHE=y' >> output/.config
         echo "BR2_CCACHE_DIR=\"$CCACHE_DIR\"" >> output/.config

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,5 +1,36 @@
 #!/bin/bash
 
+while getopts ":ahp:" opt; do
+  case $opt in
+    a)
+      echo "Build firmware images for all the platforms"
+      PLATFORMS=""
+      ;;
+    p)
+      echo "Build firmware images for the platforms: $OPTARG"
+      PLATFORMS=$OPTARG
+      ;;
+    h)
+      echo "Usage: ./ci/build.sh [options] [--]"
+      echo "-h          Print this help and exit successfully."
+      echo "-a          Build firmware images for all the platform defconfig's."
+      echo "-p          List of comma separated platform names to build images for particular platforms."
+      echo "Example:DOCKER_PREFIX=sudo ./ci/build.sh -a"
+      echo -e "\tDOCKER_PREFIX=sudo ./ci/build.sh -p firestone"
+      echo -e "\tDOCKER_PREFIX=sudo ./ci/build.sh -p garrison,palmetto,openpower_p9_mambo"
+      exit 1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG"
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument."
+      exit 1
+      ;;
+  esac
+done
+
 set -ex
 set -eo pipefail
 
@@ -45,7 +76,7 @@ EOF
 )
 	$DOCKER_PREFIX docker build -t openpower/op-build-$distro - <<< "${Dockerfile}"
 	mkdir -p output-images/$distro
-	run_docker openpower/op-build-$distro "./ci/build-all-defconfigs.sh output-images/$distro"
+	run_docker openpower/op-build-$distro "./ci/build-all-defconfigs.sh output-images/$distro $PLATFORMS"
 	if [ $? = 0 ]; then
 		mv *-images output-$distro/
 	else


### PR DESCRIPTION
This patch adds support for running ci for individual platforms,
as well as it can generate firmware images for all the platforms.

For running ci to individual platforms:
DOCKER_PREFIX=sudo  ./ci/build.sh -p palmetto
DOCKER_PREFIX=sudo  ./ci/build.sh -p garrison

For running ci to all the platforms:
DOCKER_PREFIX=sudo  ./ci/build.sh -a
DOCKER_PREFIX=sudo  ./ci/build.sh

And also it contains missing packages required for fedora23 Dockerfile.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/580)
<!-- Reviewable:end -->
