### PR TITLE
STABLE: petitboot: Update setting of kernel log level

### DIFF
--- a/openpower/package/petitboot/S14silence-console
+++ b/openpower/package/petitboot/S14silence-console
@@ -2,7 +2,7 @@
 
 case "$1" in
     start)
-        echo 0 0 7 0 > /proc/sys/kernel/printk
+        echo 1 1 1 1 > /proc/sys/kernel/printk
         ;;
 esac
 


### PR DESCRIPTION
Currently we set the current and default log levels to 0 (which is
invalid) and the minimum log level to 7 (which is very noisy). Update
the S14silence-console init script to set all these levels to the lowest
value of 1 instead.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
(cherry picked from commit 2f6155e2ee8e555a2b70cbaf2de77233ff5f3293)
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/588)
<!-- Reviewable:end -->
