### PR TITLE
STABLE: scripts: Drop support for CAICOS cards

### DIFF
--- a/openpower/scripts/firenze-firmware-whitelist
+++ b/openpower/scripts/firenze-firmware-whitelist
@@ -9,16 +9,11 @@ whitelist=(     'acenic'
                 'cxgb4'
                 'cxgb3'
                 'e100'
-                'radeon/CAICOS_me.bin'
                 'radeon/CEDAR_rlc.bin'
-                'radeon/CAICOS_mc.bin'
-                'radeon/CAICOS_pfp.bin'
                 'radeon/CEDAR_pfp.bin'
-                'radeon/CAICOS_smc.bin'
                 'radeon/CEDAR_smc.bin'
                 'radeon/CEDAR_me.bin'
-                'radeon/CYPRESS_uvd.bin'
-                'radeon/BTC_rlc.bin')
+                'radeon/CYPRESS_uvd.bin')
 
 if [ -z "${TARGET_DIR}" ] ; then
         echo "TARGET_DIR not defined, setting to $1"


### PR DESCRIPTION
The CAICOS series of radeon GPUs work on POWER but do not appear to
survive kexec. Remove support for them from Skiroot so that the GPU
won't be properly initialised until the host OS boots.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
(cherry picked from commit 379b91cc3974bfb414094e6e756d540e93ab1706)
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/649)
<!-- Reviewable:end -->
