### PR TITLE
Make installing 30-dtb_updates depend on BR2_PACKAGE_DTC

### DIFF
--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -44,8 +44,6 @@ define PETITBOOT_POST_INSTALL
 	$(INSTALL) -d -m 0755 $(TARGET_DIR)/etc/petitboot/boot.d
 	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/01-create-default-dtb \
 		$(TARGET_DIR)/etc/petitboot/boot.d/
-	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/30-dtb_updates \
-		$(TARGET_DIR)/etc/petitboot/boot.d/
 	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/90-sort-dtb \
 		$(TARGET_DIR)/etc/petitboot/boot.d/
 
@@ -71,6 +69,12 @@ define PETITBOOT_POST_INSTALL
 
 	$(MAKE) -C $(@D)/po DESTDIR=$(TARGET_DIR) install
 endef
+
+ifeq ($(BR2_PACKAGE_DTC),y)
+	PETITBOOT_POST_INSTALL_TARGET_HOOKS += \
+	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/30-dtb_updates \
+	$(TARGET_DIR)/etc/petitboot/boot.d/
+endif
 
 PETITBOOT_POST_INSTALL_TARGET_HOOKS += PETITBOOT_POST_INSTALL
 


### PR DESCRIPTION
30-dtb_updates is only created when dtc is selected.

Signed-off-by: Arthur Heymans arthur@aheymans.xyz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/697)

<!-- Reviewable:end -->
