### PR TITLE
README: add note on cross-compilation, miscellaneous improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-# OpenPower Firmware Build Environment
+# OpenPOWER Firmware Build Environment
 
-The OpenPower firmware build process uses Buildroot to create a toolchain and
+The OpenPOWER firmware build process uses Buildroot to create a toolchain and
 build the various components of the PNOR firmware, including Hostboot, Skiboot,
 OCC, Petitboot etc.
 
 ## Development
 
-Issues, Milestones, pull requests and code hosting is on github:
+Issues, Milestones, pull requests and code hosting is on GitHub:
 https://github.com/open-power/op-build
 
-Mailing list: openpower-firmware@lists.ozlabs.org  
-Info/Subscribe: https://lists.ozlabs.org/listinfo/openpower-firmware  
-Archives: https://lists.ozlabs.org/pipermail/openpower-firmware/  
+Mailing list: openpower-firmware@lists.ozlabs.org
+Info/Subscribe: https://lists.ozlabs.org/listinfo/openpower-firmware
+Archives: https://lists.ozlabs.org/pipermail/openpower-firmware/
 
 ## Building an image
+
+To build an image for a Palmetto system:
 
 ```
 git clone --recursive git@github.com:open-power/op-build.git
@@ -22,14 +24,18 @@ cd op-build
 op-build palmetto_defconfig && op-build
 ```
 
-This will build an image for a Palmetto system. There exists default
-configurations for other platforms in openpower/configs/ such as
-Habanero and Firestone.
+There are also default configurations for other platforms in
+`openpower/configs/` such as Habanero and Firestone.
 
-### Dependancies for *64-bit* Ubuntu/Debian systems
+Buildroot/op-build supports both native and cross-compilation - it will
+automatically download and build an appropriate toolchain as part of the build
+process, so you don't need to worry about setting up a
+cross-compiler. Cross-compiling from a x86-64 host is officially supported.
+
+### Dependencies for *64-bit* Ubuntu/Debian systems
 
 1. Install Ubuntu (>= 14.04) or Debian (>= 7.5) 64-bit.
-2. Enable Universe:
+2. Enable Universe (Ubuntu only):
 
         sudo apt-get install software-properties-common
         sudo add-apt-repository universe
@@ -41,7 +47,7 @@ Habanero and Firestone.
           libxml-simple-perl libxml-sax-perl libxml2-dev libxml2-utils xsltproc \
           wget bc
 
-### Dependancies for *64-bit* Fedora systems
+### Dependencies for *64-bit* Fedora systems
 
 1. Install Fedora 23 64-bit.
 2. Install the packages necessary for the build:


### PR DESCRIPTION
To a reader who has never used Buildroot before, it's not obvious that
op-build supports cross-compilation (indeed, cross-compiling from x86_64 to
ppc64 is the primary workflow of many developers). Document this
accordingly.

While we're here, make a few miscellaneous fixes:
 * Improve formatting, get rid of some extraneous spaces etc
 * Fix a couple of spelling and capitalisation errors
 * Restructure some sentences to read more nicely
 * For Ubuntu/Debian dependencies, note that the step on adding universe is
   only relevant to Ubuntu

Reported-by: Bill Alexander <bill@ohwah.com>
Signed-off-by: Andrew Donnellan <andrew.donnellan@au1.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/723)
<!-- Reviewable:end -->
