### PR TITLE
Fix SFT_IS_AST2500 config patch in src/usr/pnor/HBconfig

### DIFF
--- a/openpower/package/hostboot/p9Patches/hostboot-0006-fix-AST2500-config.patch
+++ b/openpower/package/hostboot/p9Patches/hostboot-0006-fix-AST2500-config.patch
@@ -1,4 +1,4 @@
-From b445b4bed1fedb7521663ebe8f6c02aa84b72fdd Mon Sep 17 00:00:00 2001
+From 4bd0930e6d63bf714188ecacbe06a162b3529351 Mon Sep 17 00:00:00 2001
 From: Matt Ploetz <maploetz@us.ibm.com>
 Date: Sun, 6 Nov 2016 19:20:39 -0600
 Subject: [PATCH] Change AST2400 to default only if AST2500 isn't set
@@ -9,7 +9,7 @@ Change-Id: Ic9c1da281fcdc650e7528a84377d4fbe51355c84
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/usr/pnor/HBconfig b/src/usr/pnor/HBconfig
-index c0dfde8..9043bbb 100644
+index c0dfde8..9ce13b1 100644
 --- a/src/usr/pnor/HBconfig
 +++ b/src/usr/pnor/HBconfig
 @@ -5,7 +5,7 @@ config SFC_IS_IBM_DPSS
@@ -17,7 +17,7 @@ index c0dfde8..9043bbb 100644
  
  config SFC_IS_AST2400
 -    default y
-+    default if !SFC_IS_AST2500
++    default y if !SFC_IS_AST2500
      depends on !SFC_IS_IBM_DPSS && !SFC_IS_FAKE && !SFC_IS_AST2500
      help
          The Serial Flash Controller is the AST2400 BMC.


### PR DESCRIPTION
I missed a crucial letter in my patch. Without this change Witherspoon currently fails to build. This is being fixed in upstream Hostboot as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/734)
<!-- Reviewable:end -->
