### PR TITLE
firmware-whitelist: Make whitelist accurate

### DIFF
--- a/openpower/scripts/firmware-whitelist
+++ b/openpower/scripts/firmware-whitelist
@@ -2,13 +2,14 @@
 # Scan the /lib/firmware directory of the target and delete any firmware
 # binaries that are not in our whitelist
 
-# A whitelist of entire directories or specific binary files
-whitelist=(     'acenic'
-                'bnx2'
+# A whitelist of entire directories or specific binary files. The trailing
+# slash is required.
+whitelist=(     'acenic/'
+                'bnx2/'
                 'bnx2x/bnx2x-e2-7.12.30.0.fw'
-                'cxgb4'
-                'cxgb3'
-                'e100'
+                'cxgb4/'
+                'cxgb3/'
+                'e100/'
                 'radeon/CEDAR_rlc.bin'
                 'radeon/CEDAR_pfp.bin'
                 'radeon/CEDAR_smc.bin'


### PR DESCRIPTION
The whitelist was matching bnx2* as ok, so everything in bnx2x was being
left in the image.

Signed-off-by: Joel Stanley <joel@jms.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/740)
<!-- Reviewable:end -->
