### PR TITLE
Fix Witherspoon build

### DIFF
--- a/openpower/package/hostboot/p9Patches/hostboot-0003-fix-makefile-comment.patch
+++ b/openpower/package/hostboot/p9Patches/hostboot-0003-fix-makefile-comment.patch
@@ -1,0 +1,23 @@
+From 9f70b09d7df45c22183035370e09a6bd87753dd3 Mon Sep 17 00:00:00 2001
+From: Elizabeth Liner <eliner@us.ibm.com>
+Date: Mon, 14 Nov 2016 17:07:50 -0600
+Subject: [PATCH] Makefile changes for OP Build CI Witherspoon
+
+Change-Id: Id51c5333c10e910f54d9f2fb5666ed5701efbfc0
+---
+
+diff --git a/src/usr/testcore/lib/makefile b/src/usr/testcore/lib/makefile
+index 9866637..a688b2a 100644
+--- a/src/usr/testcore/lib/makefile
++++ b/src/usr/testcore/lib/makefile
+@@ -25,8 +25,8 @@
+ ROOTPATH = ../../../..
+ 
+ MODULE = testsyslib
+-//  @TODO-RTC:151185-Turn enable all test cases
+-// TESTS = *.H
++#@TODO-RTC:151185-Turn enable all test cases
++#TESTS = *.H
+ TESTS = stltest.H
+ 
+ 


### PR DESCRIPTION
by bringing in patch currently in review that fixes makefile comments
to be actual comments

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/745)
<!-- Reviewable:end -->
