### PR TITLE
Load 'sg' kernel module automatically in petitboot

### DIFF
--- a/openpower/package/petitboot/66-add-sg-module.rules
+++ b/openpower/package/petitboot/66-add-sg-module.rules
@@ -1,0 +1,2 @@
+# load modules to scsi disks, if they aren't in kernel
+SUBSYSTEM=="scsi_device", ACTION=="add", RUN+="/sbin/modprobe sg"

--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -54,6 +54,8 @@ define PETITBOOT_POST_INSTALL
 		$(TARGET_DIR)/etc/udev/rules.d/
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL)/package/petitboot/65-md-incremental.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL)/package/petitboot/66-add-sg-module.rules \
+		$(TARGET_DIR)/etc/udev/rules.d/
 
 	ln -sf /usr/sbin/pb-udhcpc \
 		$(TARGET_DIR)/usr/share/udhcpc/default.script.d/


### PR DESCRIPTION
This patch is to add udev rule to load "sg" kernel module
automatically when petitboot is up.

Signed-off-by: Mamatha Inamdar <mamatha4@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/771)
<!-- Reviewable:end -->
