### PR TITLE
Load 'sg' kernel module automatically in petitboot

### DIFF
--- a/openpower/package/petitboot/66-add-sg-module.rules
+++ b/openpower/package/petitboot/66-add-sg-module.rules
@@ -1,0 +1,2 @@
+# load modules to scsi disks, if they aren't in kernel
+SUBSYSTEM=="scsi_device", ACTION=="add", RUN+="/sbin/modprobe sg"

--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -54,6 +54,8 @@ define PETITBOOT_POST_INSTALL
 		$(TARGET_DIR)/etc/udev/rules.d/
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL)/package/petitboot/65-md-incremental.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL)/package/petitboot/66-add-sg-module.rules \
+		$(TARGET_DIR)/etc/udev/rules.d/
 
 	ln -sf /usr/sbin/pb-udhcpc \
 		$(TARGET_DIR)/usr/share/udhcpc/default.script.d/


### PR DESCRIPTION
This patch is to add udev rule to load "sg" kernel module
automatically when petitboot is up.

On open power system update_flash -d option failed to display FW details which is due to on petitboot sg kernel module was not loaded.
This patch is to introduce udev rule to load "sg" kernel module automatically when petitboot is up. 

Below are the results after adding udev rules in petitboot to enable sg driver.

/ # lsmod
Module                  Size  Used by    Not tainted
sr_mod                 20391  0 
cdrom                  33440  1 sr_mod
isofs                  26475  1 
ext4                  381763  2 
mbcache                12491  1 ext4
jbd2                   76281  1 ext4
dm_snapshot            38778  9 
dm_bufio               22326  1 dm_snapshot
dm_mod                104471 21 dm_snapshot,dm_bufio
ofpart                  6112  0 
sg                     33665  0 
powernv_flash           6671  0 
mtd                    44831  3 ofpart,powernv_flash
sd_mod                 35336  5 

/ # update_flash -d

Firmware version:
 Product Name          : OpenPOWER Firmware
 Product Version       : IBM-garrison-ibm-OP8_v1.11_2.19
 Product Extra         : 	op-build-6ce5903
 Product Extra         : 	buildroot-81b8d98
 Product Extra         : 	skiboot-5.3.7
 Product Extra         : 	hostboot-1f6784d-02b09df
 Product Extra         : 	linux-4.4.24-openpower1-5d537af
 Product Extra         : 	petitboot-v1.2.6-8fa93f2
 Product Extra         : 	garrison-xml-3db7b6e
 Product Extra         : 	occ-69fb587
 Product Extra         : 	hostboot-bina

Signed-off-by: Mamatha Inamdar <mamatha4@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/772)
<!-- Reviewable:end -->
