### PR TITLE
package/ppe42-gcc: update to latest version 10-29-2016

### DIFF
--- a/openpower/package/ppe42-gcc/ppe42-gcc.mk
+++ b/openpower/package/ppe42-gcc/ppe42-gcc.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PPE42_GCC_VERSION ?= 72beec1539befc791ffe217f1084ee9eab7df4e5
+PPE42_GCC_VERSION ?= d8a1bac8634033a3edd4e9a22455f97318718f43
 PPE42_GCC_SITE ?= $(call github,open-power,ppe42-gcc,$(PPE42_GCC_VERSION))
 PPE42_GCC_LICENSE = GPLv3+
 


### PR DESCRIPTION
This latest fixes a buffer overflow in the compiler observed when building
under Ubuntu 14.04.

Signed-off-by: Robert Lippert <rlippert@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/779)
<!-- Reviewable:end -->
