### PR TITLE
overlay: Move `udevadm settle` to after pb-discover start

### DIFF
--- a/openpower/overlay/etc/init.d/S10udev
+++ b/openpower/overlay/etc/init.d/S10udev
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# udev	This is a minimal non-LSB version of a UDEV startup script.  It
+#	was derived by stripping down the udev-058 LSB version for use
+#	with buildroot on embedded hardware using Linux 2.6.34+ kernels.
+#
+#	You may need to customize this for your system's resource limits
+#	(including startup time!) and administration.  For example, if
+#	your early userspace has a custom initramfs or initrd you might
+#	need /dev much earlier; or without hotpluggable busses (like USB,
+#	PCMCIA, MMC/SD, and so on) your /dev might be static after boot.
+#
+#	This script assumes your system boots right into the eventual root
+#	filesystem, and that init runs this udev script before any programs
+#	needing more device nodes than the bare-bones set -- /dev/console,
+#	/dev/zero, /dev/null -- that's needed to boot and run this script.
+#
+
+# Check for missing binaries
+UDEV_BIN=/sbin/udevd
+test -x $UDEV_BIN || exit 5
+
+# Check for config file and read it
+UDEV_CONFIG=/etc/udev/udev.conf
+test -r $UDEV_CONFIG || exit 6
+. $UDEV_CONFIG
+
+case "$1" in
+    start)
+        printf "Populating ${udev_root:-/dev} using udev: "
+        printf '\000\000\000\000' > /proc/sys/kernel/hotplug
+        $UDEV_BIN -d || (echo "FAIL" && exit 1)
+        udevadm trigger --type=subsystems --action=add
+        udevadm trigger --type=devices --action=add
+        echo "done"
+        ;;
+    stop)
+        # Stop execution of events
+        udevadm control --stop-exec-queue
+        killall udevd
+        ;;
+    *)
+        echo "Usage: $0 {start|stop}"
+        exit 1
+        ;;
+esac
+
+
+exit 0

--- a/openpower/overlay/etc/init.d/S17udevsettle
+++ b/openpower/overlay/etc/init.d/S17udevsettle
@@ -1,0 +1,10 @@
+#!/bin/sh
+case "$1" in
+    start)
+        udevadm settle --timeout=30 || echo "udevadm settle failed"
+	;;
+    *)
+        exit 1;;
+esac
+
+exit 0


### PR DESCRIPTION
Add S10udev and S17udevsettle to the overlay to replace the existing
S10udev from buildroot. `udevadm settle` can wait up to 30 seconds which
delays the start of pb-discover and can cause important information to
miss the Petitboot UI. Start pb-discover first and then settle to have
the UI receive all events and bring up devices in the same time.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/789)
<!-- Reviewable:end -->
