### PR TITLE
ppe42-gcc: Host package should depend on host-ppe42-binutils

### DIFF
--- a/openpower/package/ppe42-gcc/ppe42-gcc.mk
+++ b/openpower/package/ppe42-gcc/ppe42-gcc.mk
@@ -9,6 +9,7 @@ PPE42_GCC_SITE ?= $(call github,open-power,ppe42-gcc,$(PPE42_GCC_VERSION))
 PPE42_GCC_LICENSE = GPLv3+
 
 PPE42_GCC_DEPENDENCIES = ppe42-binutils
+HOST_PPE42_GCC_DEPENDENCIES = host-ppe42-binutils
 
 PPE42_GCC_DIR = $(STAGING_DIR)/ppe42-binutils
 PPE42_GCC_BIN = $(STAGING_DIR)/ppe42-binutils/linux


### PR DESCRIPTION
If host-ppe42-gcc is built against a buildroot version of 2016.11
then the dependency of ppe42-binutils is ignored as it is not
specified as a host dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/864)
<!-- Reviewable:end -->
