### PR TITLE
op-build-env: warn when user forgets buildroot submodule

### DIFF
--- a/op-build-env
+++ b/op-build-env
@@ -5,6 +5,12 @@ if [ -e ./customrc ]; then
     source ./customrc
 fi
 
+if [ ! -e buildroot/Makefile ]; then
+	echo "Please make sure you've checked out the buildroot submodule"
+	echo "  git submodule init && git submodule update"
+	return -1
+fi
+
 export BR2_EXTERNAL=${__PWD}/openpower
 export BR2_DL_DIR=${__PWD}/dl
 


### PR DESCRIPTION
If you don't have the buildroot submodule present, the build fails in a
confusing way:

  op-build witherspoon_defconfig
  make: Entering directory '/home/benh/op-build/buildroot'
  make: *** No rule to make target 'witherspoon_defconfig'.  Stop.
  make: Leaving directory '/home/benh/op-build/buildroot

This change gives the user a better chance:

  $ . op-build-env
  Please make sure you've checked out the buildroot submodule
    git submodule init && git submodule update

Signed-off-by: Joel Stanley <joel@jms.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/865)
<!-- Reviewable:end -->
