### PR TITLE
Temporarily Revert Commit causing SGPE image size boot error

### DIFF
--- a/openpower/package/hostboot/p9Patches/hostboot-0010-Revert-Enablement-of-additional-eq_ana_bndy-rings-fo.patch
+++ b/openpower/package/hostboot/p9Patches/hostboot-0010-Revert-Enablement-of-additional-eq_ana_bndy-rings-fo.patch
@@ -1,0 +1,318 @@
+From d03736195bb489ec8cee484d4c91b6e7348d4dc9 Mon Sep 17 00:00:00 2001
+From: Bill Hoffa <wghoffa@us.ibm.com>
+Date: Tue, 28 Mar 2017 08:17:31 -0500
+Subject: [PATCH] Revert "Enablement of additional eq_ana_bndy rings for Nimbus
+ DD2"
+
+This reverts commit b4b696de54dedb5e835a0f8abca5731b1f1bdeea.
+---
+ .../p9/procedures/hwp/lib/p9_hcode_image_defines.H | 20 +------
+ .../chips/p9/procedures/hwp/pm/p9_scan_ring_util.C | 40 ++-----------
+ src/import/chips/p9/utils/imageProcs/p9_ringId.C   | 30 +++-------
+ src/import/chips/p9/utils/imageProcs/p9_ringId.H   | 67 ++++------------------
+ src/import/chips/p9/utils/imageProcs/p9_ring_id.h  | 24 ++------
+ 5 files changed, 32 insertions(+), 149 deletions(-)
+
+diff --git a/src/import/chips/p9/procedures/hwp/lib/p9_hcode_image_defines.H b/src/import/chips/p9/procedures/hwp/lib/p9_hcode_image_defines.H
+index f6b9eea..6df1dbf 100644
+--- a/src/import/chips/p9/procedures/hwp/lib/p9_hcode_image_defines.H
++++ b/src/import/chips/p9/procedures/hwp/lib/p9_hcode_image_defines.H
+@@ -488,24 +488,10 @@ typedef struct
+     uint16_t    eqAnaBndyRingBucket23;
+     uint16_t    eqAnaBndyRingBucket24;
+     uint16_t    eqAnaBndyRingBucket25;
+-    uint16_t    eqAnaBndyRingl3dccBucket;
++    uint16_t    eqAnaBndyRingl3dccBucket26;
+     uint16_t    eqAnaModeRing;
+-    uint16_t    eqAnaBndyRingBucket26;
+-    uint16_t    eqAnaBndyRingBucket27;
+-    uint16_t    eqAnaBndyRingBucket28;
+-    uint16_t    eqAnaBndyRingBucket29;
+-    uint16_t    eqAnaBndyRingBucket30;
+-    uint16_t    eqAnaBndyRingBucket31;
+-    uint16_t    eqAnaBndyRingBucket32;
+-    uint16_t    eqAnaBndyRingBucket33;
+-    uint16_t    eqAnaBndyRingBucket34;
+-    uint16_t    eqAnaBndyRingBucket35;
+-    uint16_t    eqAnaBndyRingBucket36;
+-    uint16_t    eqAnaBndyRingBucket37;
+-    uint16_t    eqAnaBndyRingBucket38;
+-    uint16_t    eqAnaBndyRingBucket39;
+-    uint16_t    eqAnaBndyRingBucket40;
+-    uint16_t    eqAnaBndyRingBucket41;
++    uint16_t    ex_l2_fure_1;
++    uint16_t    ex_l3_fure_1;
+ } QuadCmnRingsList_t;
+ 
+ typedef struct
+diff --git a/src/import/chips/p9/procedures/hwp/pm/p9_scan_ring_util.C b/src/import/chips/p9/procedures/hwp/pm/p9_scan_ring_util.C
+index 63e07e0..3df8232 100644
+--- a/src/import/chips/p9/procedures/hwp/pm/p9_scan_ring_util.C
++++ b/src/import/chips/p9/procedures/hwp/pm/p9_scan_ring_util.C
+@@ -182,24 +182,10 @@ RingBucket::RingBucket( PlatId i_plat, uint8_t* i_pRingStart, RingDebugMode_t i_
+             { eq_ana_bndy_bucket_23,    0,  0 },
+             { eq_ana_bndy_bucket_24,    0,  0 },
+             { eq_ana_bndy_bucket_25,    0,  0 },
+-            { eq_ana_bndy_bucket_l3dcc, 0,  0 },
++            { eq_ana_bndy_l3dcc_bucket_26, 0, 0 },
+             { eq_ana_mode,              0,  0 },
+-            { eq_ana_bndy_bucket_26,    0,  0 },
+-            { eq_ana_bndy_bucket_27,    0,  0 },
+-            { eq_ana_bndy_bucket_28,    0,  0 },
+-            { eq_ana_bndy_bucket_29,    0,  0 },
+-            { eq_ana_bndy_bucket_30,    0,  0 },
+-            { eq_ana_bndy_bucket_31,    0,  0 },
+-            { eq_ana_bndy_bucket_32,    0,  0 },
+-            { eq_ana_bndy_bucket_33,    0,  0 },
+-            { eq_ana_bndy_bucket_34,    0,  0 },
+-            { eq_ana_bndy_bucket_35,    0,  0 },
+-            { eq_ana_bndy_bucket_36,    0,  0 },
+-            { eq_ana_bndy_bucket_37,    0,  0 },
+-            { eq_ana_bndy_bucket_38,    0,  0 },
+-            { eq_ana_bndy_bucket_39,    0,  0 },
+-            { eq_ana_bndy_bucket_40,    0,  0 },
+-            { eq_ana_bndy_bucket_41,    0,  0 },
++            { ex_l2_fure_1,             0,  0 },
++            { ex_l3_fure_1,             0,  0 },
+         };
+ 
+         RingProfile l_quadSpecRings[TEMP_MAX_QUAD_SPEC_RINGS * MAX_QUADS_PER_CHIP] =
+@@ -321,24 +307,10 @@ RingBucket::RingBucket( PlatId i_plat, uint8_t* i_pRingStart, RingDebugMode_t i_
+         iv_ringName[ eq_ana_bndy_bucket_23 ]    =   (char*)"eq_ana_bndy_bucket_23";
+         iv_ringName[ eq_ana_bndy_bucket_24 ]    =   (char*)"eq_ana_bndy_bucket_24";
+         iv_ringName[ eq_ana_bndy_bucket_25 ]    =   (char*)"eq_ana_bndy_bucket_25";
+-        iv_ringName[ eq_ana_bndy_bucket_l3dcc ] =   (char*)"eq_ana_bndy_bucket_l3dcc";
++        iv_ringName[ eq_ana_bndy_l3dcc_bucket_26 ]      =   (char*)"eq_ana_bndy_l3dcc_bucket_26";
+         iv_ringName[ eq_ana_mode ]              =   (char*)"eq_ana_mode          ";
+-        iv_ringName[ eq_ana_bndy_bucket_26 ]    =   (char*)"eq_ana_bndy_bucket_26";
+-        iv_ringName[ eq_ana_bndy_bucket_27 ]    =   (char*)"eq_ana_bndy_bucket_27";
+-        iv_ringName[ eq_ana_bndy_bucket_28 ]    =   (char*)"eq_ana_bndy_bucket_28";
+-        iv_ringName[ eq_ana_bndy_bucket_29 ]    =   (char*)"eq_ana_bndy_bucket_29";
+-        iv_ringName[ eq_ana_bndy_bucket_30 ]    =   (char*)"eq_ana_bndy_bucket_30";
+-        iv_ringName[ eq_ana_bndy_bucket_31 ]    =   (char*)"eq_ana_bndy_bucket_31";
+-        iv_ringName[ eq_ana_bndy_bucket_32 ]    =   (char*)"eq_ana_bndy_bucket_32";
+-        iv_ringName[ eq_ana_bndy_bucket_33 ]    =   (char*)"eq_ana_bndy_bucket_33";
+-        iv_ringName[ eq_ana_bndy_bucket_34 ]    =   (char*)"eq_ana_bndy_bucket_34";
+-        iv_ringName[ eq_ana_bndy_bucket_35 ]    =   (char*)"eq_ana_bndy_bucket_35";
+-        iv_ringName[ eq_ana_bndy_bucket_36 ]    =   (char*)"eq_ana_bndy_bucket_36";
+-        iv_ringName[ eq_ana_bndy_bucket_37 ]    =   (char*)"eq_ana_bndy_bucket_37";
+-        iv_ringName[ eq_ana_bndy_bucket_38 ]    =   (char*)"eq_ana_bndy_bucket_38";
+-        iv_ringName[ eq_ana_bndy_bucket_39 ]    =   (char*)"eq_ana_bndy_bucket_39";
+-        iv_ringName[ eq_ana_bndy_bucket_40 ]    =   (char*)"eq_ana_bndy_bucket_40";
+-        iv_ringName[ eq_ana_bndy_bucket_41 ]    =   (char*)"eq_ana_bndy_bucket_41";
++        iv_ringName[ ex_l2_fure_1 ]             =   (char*)"ex_l2_fure_1         ";
++        iv_ringName[ ex_l3_fure_1 ]             =   (char*)"ex_l3_fure_1         ";
+         iv_ringName[ eq_repr ]                  =   (char*)"eq_repr              ";
+         iv_ringName[ ex_l3_repr ]               =   (char*)"ex_l3_repr           ";
+         iv_ringName[ ex_l2_repr ]               =   (char*)"ex_l2_repr           ";
+diff --git a/src/import/chips/p9/utils/imageProcs/p9_ringId.C b/src/import/chips/p9/utils/imageProcs/p9_ringId.C
+index 1d21023..3bd7d2a 100644
+--- a/src/import/chips/p9/utils/imageProcs/p9_ringId.C
++++ b/src/import/chips/p9/utils/imageProcs/p9_ringId.C
+@@ -395,32 +395,18 @@ const GenRingIdList RING_ID_LIST_COMMON[] =
+     {"eq_ana_bndy_bucket_23"      , 0x29, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+     {"eq_ana_bndy_bucket_24"      , 0x2a, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+     {"eq_ana_bndy_bucket_25"      , 0x2b, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_l3dcc"   , 0x2c, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
++    {"eq_ana_bndy_l3dcc_bucket_26", 0x2c, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+     {"eq_ana_mode"                , 0x2d, 0x10, 0x10, EKB_RING    , 0x10030101},
+-    {"eq_ana_bndy_bucket_26"      , 0x2e, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_27"      , 0x2f, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_28"      , 0x30, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_29"      , 0x31, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_30"      , 0x32, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_31"      , 0x33, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_32"      , 0x34, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_33"      , 0x35, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_34"      , 0x36, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_35"      , 0x37, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_36"      , 0x38, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_37"      , 0x39, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_38"      , 0x3a, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_39"      , 0x3b, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_40"      , 0x3c, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
+-    {"eq_ana_bndy_bucket_41"      , 0x3d, 0x10, 0x10, EKB_FSM_RING, 0x10030108},
++    {"ex_l2_fure_1"               , 0x2e, 0x10, 0x10, EKB_RING    , 0x1003040F},
++    {"ex_l3_fure_1"               , 0x2f, 0x10, 0x10, EKB_RING    , 0x1003100F},
+ };
+ const GenRingIdList RING_ID_LIST_INSTANCE[] =
+ {
+-    {"eq_repr"                    , 0x3e, 0x10, 0x1b, VPD_RING    , 0x10036086},
+-    {"ex_l3_repr"                 , 0x3f, 0x10, 0x1b, VPD_RING    , 0x10031006},
+-    {"ex_l2_repr"                 , 0x40, 0x10, 0x1b, VPD_RING    , 0x10030406},
+-    {"ex_l3_refr_repr"            , 0x41, 0x10, 0x1b, VPD_RING    , 0x10030046},
+-    {"ex_l3_refr_time"            , 0x42, 0x10, 0x1b, VPD_RING    , 0x10030047},
++    {"eq_repr"                    , 0x30, 0x10, 0x1b, VPD_RING    , 0x10036086},
++    {"ex_l3_repr"                 , 0x31, 0x10, 0x1b, VPD_RING    , 0x10031006},
++    {"ex_l2_repr"                 , 0x32, 0x10, 0x1b, VPD_RING    , 0x10030406},
++    {"ex_l3_refr_repr"            , 0x33, 0x10, 0x1b, VPD_RING    , 0x10030046},
++    {"ex_l3_refr_time"            , 0x34, 0x10, 0x1b, VPD_RING    , 0x10030047},
+ };
+ const RingVariantOrder RING_VARIANT_ORDER[] = { BASE, CC, RL };
+ };
+diff --git a/src/import/chips/p9/utils/imageProcs/p9_ringId.H b/src/import/chips/p9/utils/imageProcs/p9_ringId.H
+index a0e8261..b49ad89 100644
+--- a/src/import/chips/p9/utils/imageProcs/p9_ringId.H
++++ b/src/import/chips/p9/utils/imageProcs/p9_ringId.H
+@@ -778,24 +778,10 @@ enum RingOffset
+     eq_ana_bndy_bucket_23  = 41,
+     eq_ana_bndy_bucket_24  = 42,
+     eq_ana_bndy_bucket_25  = 43,
+-    eq_ana_bndy_bucket_l3dcc  = 44,
++    eq_ana_bndy_l3dcc_bucket_26  = 44,
+     eq_ana_mode     = 45,
+-    eq_ana_bndy_bucket_26 = 46,
+-    eq_ana_bndy_bucket_27 = 47,
+-    eq_ana_bndy_bucket_28 = 48,
+-    eq_ana_bndy_bucket_29 = 49,
+-    eq_ana_bndy_bucket_30 = 50,
+-    eq_ana_bndy_bucket_31 = 51,
+-    eq_ana_bndy_bucket_32 = 52,
+-    eq_ana_bndy_bucket_33 = 53,
+-    eq_ana_bndy_bucket_34 = 54,
+-    eq_ana_bndy_bucket_35 = 55,
+-    eq_ana_bndy_bucket_36 = 56,
+-    eq_ana_bndy_bucket_37 = 57,
+-    eq_ana_bndy_bucket_38 = 58,
+-    eq_ana_bndy_bucket_39 = 59,
+-    eq_ana_bndy_bucket_40 = 60,
+-    eq_ana_bndy_bucket_41 = 61,
++    ex_l2_fure_1    = 46,
++    ex_l3_fure_1    = 47,
+ 
+     // Instance Rings
+     eq_repr         = (0 | INSTANCE_RING_MARK),
+@@ -808,7 +794,7 @@ enum RingOffset
+ static const CHIPLET_DATA g_eqData =
+ {
+     16, // Quad Chiplet ID range is 16 - 21. The base ID is 16.
+-    62, // 62 common rings for Quad chiplet.
++    48, // 48 common rings for Quad chiplet.
+     5,  // 5 instance specific rings for each EQ chiplet
+     9   // 9 different rings since 2 per EX ring and 1 per EQ
+ };
+@@ -1085,7 +1071,7 @@ static const ringProperties_t RING_PROPERTIES[NUM_RING_IDS] =
+     { EQ::eq_ana_bndy_bucket_23          , "eq_ana_bndy_bucket_23"       , EQ_TYPE    }, // 215
+     { EQ::eq_ana_bndy_bucket_24          , "eq_ana_bndy_bucket_24"       , EQ_TYPE    }, // 216
+     { EQ::eq_ana_bndy_bucket_25          , "eq_ana_bndy_bucket_25"       , EQ_TYPE    }, // 217
+-    { EQ::eq_ana_bndy_bucket_l3dcc       , "eq_ana_bndy_bucket_l3dcc"    , EQ_TYPE    }, // 218
++    { EQ::eq_ana_bndy_l3dcc_bucket_26    , "eq_ana_bndy_l3dcc_bucket_26" , EQ_TYPE    }, // 218
+     { EQ::eq_ana_mode                    , "eq_ana_mode"                 , EQ_TYPE    }, // 219
+     { EQ::eq_repr                        , "eq_repr"                     , EQ_TYPE    }, // 220
+     { EQ::ex_l3_repr                     , "ex_l3_repr"                  , EQ_TYPE    }, // 221
+@@ -1096,25 +1082,10 @@ static const ringProperties_t RING_PROPERTIES[NUM_RING_IDS] =
+     { EC::ec_time                        , "ec_time"                     , EC_TYPE    }, // 226
+     { EC::ec_mode                        , "ec_mode"                     , EC_TYPE    }, // 227
+     { EC::ec_repr                        , "ec_repr"                     , EC_TYPE    }, // 228
+-    { INVALID_RING                       , "invalid"                     , EQ_TYPE    }, // 229
+-    { INVALID_RING                       , "invalid"                     , EQ_TYPE    }, // 230
++    { EQ::ex_l2_fure_1                   , "ex_l2_fure_1"                , EQ_TYPE    }, // 229
++    { EQ::ex_l3_fure_1                   , "ex_l3_fure_1"                , EQ_TYPE    }, // 230
+     { EC::ec_abst                        , "ec_abst"                     , EC_TYPE    }, // 231
+-    { EQ::eq_ana_bndy_bucket_26          , "eq_ana_bndy_bucket_26"       , EQ_TYPE    }, // 232
+-    { EQ::eq_ana_bndy_bucket_27          , "eq_ana_bndy_bucket_27"       , EQ_TYPE    }, // 233
+-    { EQ::eq_ana_bndy_bucket_28          , "eq_ana_bndy_bucket_28"       , EQ_TYPE    }, // 234
+-    { EQ::eq_ana_bndy_bucket_29          , "eq_ana_bndy_bucket_29"       , EQ_TYPE    }, // 235
+-    { EQ::eq_ana_bndy_bucket_30          , "eq_ana_bndy_bucket_30"       , EQ_TYPE    }, // 236
+-    { EQ::eq_ana_bndy_bucket_31          , "eq_ana_bndy_bucket_31"       , EQ_TYPE    }, // 237
+-    { EQ::eq_ana_bndy_bucket_32          , "eq_ana_bndy_bucket_32"       , EQ_TYPE    }, // 238
+-    { EQ::eq_ana_bndy_bucket_33          , "eq_ana_bndy_bucket_33"       , EQ_TYPE    }, // 239
+-    { EQ::eq_ana_bndy_bucket_34          , "eq_ana_bndy_bucket_34"       , EQ_TYPE    }, // 240
+-    { EQ::eq_ana_bndy_bucket_35          , "eq_ana_bndy_bucket_35"       , EQ_TYPE    }, // 241
+-    { EQ::eq_ana_bndy_bucket_36          , "eq_ana_bndy_bucket_36"       , EQ_TYPE    }, // 242
+-    { EQ::eq_ana_bndy_bucket_37          , "eq_ana_bndy_bucket_37"       , EQ_TYPE    }, // 243
+-    { EQ::eq_ana_bndy_bucket_38          , "eq_ana_bndy_bucket_38"       , EQ_TYPE    }, // 244
+-    { EQ::eq_ana_bndy_bucket_39          , "eq_ana_bndy_bucket_39"       , EQ_TYPE    }, // 245
+-    { EQ::eq_ana_bndy_bucket_40          , "eq_ana_bndy_bucket_40"       , EQ_TYPE    }, // 246
+-    { EQ::eq_ana_bndy_bucket_41          , "eq_ana_bndy_bucket_41"       , EQ_TYPE    }, // 247
++
+ };
+ #endif
+ #ifdef __PPE__
+@@ -1338,7 +1309,7 @@ static const ringProperties_t RING_PROPERTIES[NUM_RING_IDS] =
+     { EQ::eq_ana_bndy_bucket_23          , EQ_TYPE    }, // 215
+     { EQ::eq_ana_bndy_bucket_24          , EQ_TYPE    }, // 216
+     { EQ::eq_ana_bndy_bucket_25          , EQ_TYPE    }, // 217
+-    { EQ::eq_ana_bndy_bucket_l3dcc       , EQ_TYPE    }, // 218
++    { EQ::eq_ana_bndy_l3dcc_bucket_26    , EQ_TYPE    }, // 218
+     { EQ::eq_ana_mode                    , EQ_TYPE    }, // 219
+     { EQ::eq_repr                        , EQ_TYPE    }, // 220
+     { EQ::ex_l3_repr                     , EQ_TYPE    }, // 221
+@@ -1349,25 +1320,9 @@ static const ringProperties_t RING_PROPERTIES[NUM_RING_IDS] =
+     { EC::ec_time                        , EC_TYPE    }, // 226
+     { EC::ec_mode                        , EC_TYPE    }, // 227
+     { EC::ec_repr                        , EC_TYPE    }, // 228
+-    { INVALID_RING                       , EQ_TYPE    }, // 229
+-    { INVALID_RING                       , EQ_TYPE    }, // 230
++    { EQ::ex_l2_fure_1                   , EQ_TYPE    }, // 229
++    { EQ::ex_l3_fure_1                   , EQ_TYPE    }, // 230
+     { EC::ec_abst                        , EC_TYPE    }, // 231
+-    { EQ::eq_ana_bndy_bucket_26          , EQ_TYPE    }, // 232
+-    { EQ::eq_ana_bndy_bucket_27          , EQ_TYPE    }, // 233
+-    { EQ::eq_ana_bndy_bucket_28          , EQ_TYPE    }, // 234
+-    { EQ::eq_ana_bndy_bucket_29          , EQ_TYPE    }, // 235
+-    { EQ::eq_ana_bndy_bucket_30          , EQ_TYPE    }, // 236
+-    { EQ::eq_ana_bndy_bucket_31          , EQ_TYPE    }, // 237
+-    { EQ::eq_ana_bndy_bucket_32          , EQ_TYPE    }, // 238
+-    { EQ::eq_ana_bndy_bucket_33          , EQ_TYPE    }, // 239
+-    { EQ::eq_ana_bndy_bucket_34          , EQ_TYPE    }, // 240
+-    { EQ::eq_ana_bndy_bucket_35          , EQ_TYPE    }, // 241
+-    { EQ::eq_ana_bndy_bucket_36          , EQ_TYPE    }, // 242
+-    { EQ::eq_ana_bndy_bucket_37          , EQ_TYPE    }, // 243
+-    { EQ::eq_ana_bndy_bucket_38          , EQ_TYPE    }, // 244
+-    { EQ::eq_ana_bndy_bucket_39          , EQ_TYPE    }, // 245
+-    { EQ::eq_ana_bndy_bucket_40          , EQ_TYPE    }, // 246
+-    { EQ::eq_ana_bndy_bucket_41          , EQ_TYPE    }, // 247
+ };
+ #endif
+ 
+diff --git a/src/import/chips/p9/utils/imageProcs/p9_ring_id.h b/src/import/chips/p9/utils/imageProcs/p9_ring_id.h
+index 1b4860d..71634a8 100644
+--- a/src/import/chips/p9/utils/imageProcs/p9_ring_id.h
++++ b/src/import/chips/p9/utils/imageProcs/p9_ring_id.h
+@@ -299,7 +299,7 @@ enum RingID
+     eq_ana_bndy_bucket_23 = 215,
+     eq_ana_bndy_bucket_24 = 216,
+     eq_ana_bndy_bucket_25 = 217,
+-    eq_ana_bndy_bucket_l3dcc = 218,
++    eq_ana_bndy_l3dcc_bucket_26 = 218,
+     eq_ana_mode = 219,
+ 
+     // Quad Chiplet Rings
+@@ -320,30 +320,14 @@ enum RingID
+     // EC0 - EC23 instance specific Ring
+     ec_repr = 228,
+ 
+-    // Values 229-230 unused
++    // Additional rings
++    ex_l2_fure_1 = 229,
++    ex_l3_fure_1 = 230,
+ 
+     // Core Chiplet Rings
+     // ABIST engine mode
+     ec_abst = 231,
+ 
+-    // Additional rings for Nimbus DD2
+-    eq_ana_bndy_bucket_26 = 232,
+-    eq_ana_bndy_bucket_27 = 233,
+-    eq_ana_bndy_bucket_28 = 234,
+-    eq_ana_bndy_bucket_29 = 235,
+-    eq_ana_bndy_bucket_30 = 236,
+-    eq_ana_bndy_bucket_31 = 237,
+-    eq_ana_bndy_bucket_32 = 238,
+-    eq_ana_bndy_bucket_33 = 239,
+-    eq_ana_bndy_bucket_34 = 240,
+-    eq_ana_bndy_bucket_35 = 241,
+-    eq_ana_bndy_bucket_36 = 242,
+-    eq_ana_bndy_bucket_37 = 243,
+-    eq_ana_bndy_bucket_38 = 244,
+-    eq_ana_bndy_bucket_39 = 245,
+-    eq_ana_bndy_bucket_40 = 246,
+-    eq_ana_bndy_bucket_41 = 247,
+-
+     //***************************
+     // Rings needed for SBE - End
+     //***************************
+-- 
+1.8.2.2
+


### PR DESCRIPTION
  - This patch can be removed when the dependent reference
    image is available