### PR TITLE
ppe42-gcc: Fix implicit dependencies

### DIFF
--- a/openpower/package/ppe42-gcc/ppe42-gcc.mk
+++ b/openpower/package/ppe42-gcc/ppe42-gcc.mk
@@ -8,8 +8,8 @@ PPE42_GCC_VERSION ?= d8a1bac8634033a3edd4e9a22455f97318718f43
 PPE42_GCC_SITE ?= $(call github,open-power,ppe42-gcc,$(PPE42_GCC_VERSION))
 PPE42_GCC_LICENSE = GPLv3+
 
-PPE42_GCC_DEPENDENCIES = ppe42-binutils
-HOST_PPE42_GCC_DEPENDENCIES = host-ppe42-binutils
+PPE42_GCC_DEPENDENCIES = ppe42-binutils gmp mpfr mpc
+HOST_PPE42_GCC_DEPENDENCIES = host-ppe42-binutils host-gmp host-mpfr host-mpc
 
 PPE42_GCC_DIR = $(STAGING_DIR)/ppe42-binutils
 PPE42_GCC_BIN = $(STAGING_DIR)/ppe42-binutils/linux


### PR DESCRIPTION
This fixes issues building the host-ppe42-gcc with a cleanly checked out
op-build.

Signed-off-by: William A. Kennington III <wak@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1024)
<!-- Reviewable:end -->
