### PR TITLE
Make installing 30-dtb-updates depend on BR2_PACKAGE_DTC

### DIFF
--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -44,8 +44,6 @@ define PETITBOOT_POST_INSTALL
 	$(INSTALL) -d -m 0755 $(TARGET_DIR)/etc/petitboot/boot.d
 	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/01-create-default-dtb \
 		$(TARGET_DIR)/etc/petitboot/boot.d/
-	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/30-dtb-updates \
-		$(TARGET_DIR)/etc/petitboot/boot.d/
 	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/90-sort-dtb \
 		$(TARGET_DIR)/etc/petitboot/boot.d/
 
@@ -72,6 +70,15 @@ define PETITBOOT_POST_INSTALL
 	$(MAKE) -C $(@D)/po DESTDIR=$(TARGET_DIR) install
 endef
 
+define PETITBOOT_POST_INSTALL_DTB
+	$(INSTALL) -D -m 0755 $(@D)/utils/hooks/30-dtb-updates \
+		$(TARGET_DIR)/etc/petitboot/boot.d/
+endef
+
 PETITBOOT_POST_INSTALL_TARGET_HOOKS += PETITBOOT_POST_INSTALL
+
+ifeq ($(BR2_PACKAGE_DTC),y)
+	PETITBOOT_POST_INSTALL_TARGET_HOOKS += PETITBOOT_POST_INSTALL_DTB
+endif
 
 $(eval $(autotools-package))


### PR DESCRIPTION
30-dtb-updates is only created when dtc is selected.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>
Naming and hook update fixed by:
Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

This fixes and supersedes https://github.com/open-power/op-build/pull/697

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1032)
<!-- Reviewable:end -->
