### PR TITLE
    Load 'sg' kernel module automatically in petitboot

### DIFF
--- a/openpower/package/petitboot/66-add-sg-module.rules
+++ b/openpower/package/petitboot/66-add-sg-module.rules
@@ -1,0 +1,2 @@
+# load modules to scsi disks, if they aren't in kernel
+SUBSYSTEM=="scsi", ENV{DEVTYPE}=="scsi_device", TEST!="[module/sg]", RUN+="/sbin/modprobe sg"

--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -61,6 +61,8 @@ define PETITBOOT_POST_INSTALL
 		$(TARGET_DIR)/etc/udev/rules.d/
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_OP_BUILD_PATH)/package/petitboot/65-md-incremental.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL)/package/petitboot/66-add-sg-module.rules \
+		$(TARGET_DIR)/etc/udev/rules.d/
 
 	ln -sf /usr/sbin/pb-udhcpc \
 		$(TARGET_DIR)/usr/share/udhcpc/default.script.d/


### PR DESCRIPTION
    
    On open power system update_flash -d option failed to display FW details
    which is due to on petitboot sg kernel module was not loaded.
    
    This patch is to introduce udev rule to load "sg" kernel module
    automatically when petitboot is up.

Signed-off-by: Mamatha Inamdar <mamatha4@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1117)
<!-- Reviewable:end -->
