### PR TITLE
Enable BMC Mbox Protocol

### DIFF
--- a/openpower/configs/hostboot/witherspoon.config
+++ b/openpower/configs/hostboot/witherspoon.config
@@ -1,6 +1,8 @@
-# The Serial Flash Controller is the AST2400 BMC.
-set   SFC_IS_AST2500
+# The BMC MBOX Protocol is used to access PNOR
+unset SFC_IS_AST2500
 unset SFC_IS_AST2400
+set   PNORDD_IS_BMCMBOX
+unset PNORDD_IS_SFC
 unset BMC_DOES_SFC_INIT
 unset SFC_IS_IBM_DPSS
 set   ALLOW_MICRON_PNOR

--- a/openpower/configs/hostboot/zaius.config
+++ b/openpower/configs/hostboot/zaius.config
@@ -1,6 +1,8 @@
-# The Serial Flash Controller is the AST2500 BMC.
-set   SFC_IS_AST2500
+# The BMC MBOX Protocol is used to access PNOR
+unset SFC_IS_AST2500
 unset SFC_IS_AST2400
+set   PNORDD_IS_BMCMBOX
+unset PNORDD_IS_SFC
 unset BMC_DOES_SFC_INIT
 unset SFC_IS_IBM_DPSS
 set   ALLOW_MICRON_PNOR


### PR DESCRIPTION
   - This will enable Hostboot to use the BMC Mbox protocol to use
     the BMC to do PNOR accesses
   - Enable for Witherspoon + Zaius systems

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1119)
<!-- Reviewable:end -->
