### PR TITLE
Moved common unit and scale information for mcs unit to the  nodes specific to bandwidth computation. Fixed in POWER9 DTS file.

### DIFF
--- a/openpower/package/ima-catalog/ima-catalog.mk
+++ b/openpower/package/ima-catalog/ima-catalog.mk
@@ -3,7 +3,7 @@
 # ima-catalog.mk
 #
 ################################################################################
-IMA_CATALOG_VERSION ?= 0e3bbcb56dfc60fd99b862406ecd3e117117d9af
+IMA_CATALOG_VERSION ?= 0708ccddbf95cd524be2f28a5fbb07799269cdde
 IMA_CATALOG_SITE ?= $(call github,open-power,ima-catalog,$(IMA_CATALOG_VERSION))
 IMA_CATALOG_LICENSE = Apache-2.0
 IMA_CATALOG_DEPENDENCIES = host-dtc host-xz

--- a/openpower/package/ima-catalog/ima-catalog.mk
+++ b/openpower/package/ima-catalog/ima-catalog.mk
@@ -3,7 +3,7 @@
 # ima-catalog.mk
 #
 ################################################################################
-IMA_CATALOG_VERSION ?= 0708ccddbf95cd524be2f28a5fbb07799269cdde
+IMA_CATALOG_VERSION ?= e3bb899021f3f0f493ee69c0b2f9a65e8836c51e
 IMA_CATALOG_SITE ?= $(call github,open-power,ima-catalog,$(IMA_CATALOG_VERSION))
 IMA_CATALOG_LICENSE = Apache-2.0
 IMA_CATALOG_DEPENDENCIES = host-dtc host-xz


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1138)
<!-- Reviewable:end -->
