### PR TITLE
Updating wofdata variables to have defaults for all p9 machines

### DIFF
--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -67,11 +67,13 @@ config BR2_HOSTBOOT_BINARY_WINK_FILENAME
 
 config BR2_WOFDATA_FILENAME
         string "Name of wofdata original file"
+        default "wof_output"
         help
             String used to define name of wofdata original file
 
 config BR2_WOFDATA_BINARY_FILENAME
         string "Name of wofdata binary file"
+        default "wofdata.bin.ecc"
         help
             String used to define name of wofdata binary ecc'd file
 


### PR DESCRIPTION
All P9 machines need to have a default for these variables, otherwise they fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1141)
<!-- Reviewable:end -->
