### PR TITLE
Update libflash and install pflash utility

### DIFF
--- a/openpower/package/libflash/Config.in
+++ b/openpower/package/libflash/Config.in
@@ -2,3 +2,8 @@ config BR2_PACKAGE_LIBFLASH
 	bool "libflash"
 	help
 	  Build libflash shared library
+
+config BR2_PACKAGE_PFLASH
+	bool "pflash"
+	help
+	  Install pflash utility to target

--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -17,22 +17,29 @@ LIBFLASH_MAKE_OPTS += CC="$(TARGET_CC)" LD="$(TARGET_LD)" \
 		     OBJCOPY="$(TARGET_OBJCOPY)" OBJDUMP="$(TARGET_OBJDUMP)" \
 		     SIZE="$(TARGET_CROSS)size"
 
+LIBFLASH_MAKE_ENV = \
+	SKIBOOT_VERSION=$(LIBFLASH_VERSION) \
+	       $(MAKE1) $(LIBFLASH_MAKE_OPTS) CROSS_COMPILE=$(TARGET_CROSS)
+
+
 define LIBFLASH_BUILD_CMDS
-	PREFIX=$(STAGING_DIR)/usr SKIBOOT_VERSION=$(LIBFLASH_VERSION) \
-	       $(MAKE1) $(LIBFLASH_MAKE_OPTS) CROSS_COMPILE=$(TARGET_CROSS) \
-	       -C $(@D)/external/shared
+	PREFIX=$(STAGING_DIR)/usr $(LIBFLASH_MAKE_ENV) -C $(@D)/external/shared
+	$(if $(BR2_PACKAGE_PFLASH),
+		PREFIX=$(STAGING_DIR)/usr $(LIBFLASH_MAKE_ENV) \
+		       -C $(@D)/external/pflash)
 endef
 
 define LIBFLASH_INSTALL_STAGING_CMDS
-	PREFIX=$(STAGING_DIR)/usr SKIBOOT_VERSION=$(LIBFLASH_VERSION) \
-	       $(MAKE1) $(LIBFLASH_MAKE_OPTS) CROSS_COMPILE=$(TARGET_CROSS) \
-	       -C $(@D)/external/shared install
+	PREFIX=$(STAGING_DIR)/usr $(LIBFLASH_MAKE_ENV) -C $(@D)/external/shared \
+	       install
 endef
 
 define LIBFLASH_INSTALL_TARGET_CMDS
-	PREFIX=$(TARGET_DIR)/usr SKIBOOT_VERSION=$(LIBFLASH_VERSION) \
-	       $(MAKE1) $(LIBFLASH_MAKE_OPTS) CROSS_COMPILE=$(TARGET_CROSS) \
-	       -C $(@D)/external/shared install-lib
+	PREFIX=$(TARGET_DIR)/usr $(LIBFLASH_MAKE_ENV) -C $(@D)/external/shared \
+	       install-lib
+	$(if $(BR2_PACKAGE_PFLASH),
+		DESTDIR=$(TARGET_DIR) $(LIBFLASH_MAKE_ENV) \
+		       -C $(@D)/external/pflash install)
 endef
 
 $(eval $(generic-package))

--- a/openpower/package/petitboot/Config.in
+++ b/openpower/package/petitboot/Config.in
@@ -27,6 +27,7 @@ config BR2_PACKAGE_PETITBOOT_MTD
 	bool "petitboot-mtd"
 	depends on BR2_PACKAGE_PETITBOOT
 	select BR2_PACKAGE_LIBFLASH
+	select BR2_PACKAGE_PFLASH
 	help
 	  Adds Petitboot support for MTD devices
 


### PR DESCRIPTION
Extend the libflash package to also install the pflash utility. This
enables users to query and modify the PNOR safely from the host, as well
as supporting future automation changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1166)
<!-- Reviewable:end -->
