### PR TITLE
xmltohb.pl: pass mrw scratch dir as src-output-dir

### DIFF
--- a/openpower/package/machine-xml/machine-xml.mk
+++ b/openpower/package/machine-xml/machine-xml.mk
@@ -81,7 +81,7 @@ define MACHINE_XML_BUILD_CMDS
         $(MRW_HB_TOOLS)/xmltohb.pl  \
             --hb-xml-file=$(MRW_HB_TOOLS)/temporary_hb.hb.xml \
             --fapi-attributes-xml-file=$(MRW_HB_TOOLS)/fapiattrs.xml \
-            --src-output-dir=none \
+            --src-output-dir=$(MRW_HB_TOOLS)/ \
             --img-output-dir=$(MRW_HB_TOOLS)/ \
             --vmm-consts-file=$(MRW_HB_TOOLS)/vmmconst.h --noshort-enums \
             --bios-xml-file=$(OPENPOWER_BIOS_XML_CONFIG_FILE) \


### PR DESCRIPTION
This will allow the generation of PersistRwAttrList.csv in
output/staging/openpower_mrw_scratch/ instead of buildroot

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1196)
<!-- Reviewable:end -->
