### PR TITLE
scripts/release-notes: Don't try to clone redbud-xml

### DIFF
--- a/openpower/scripts/release-notes
+++ b/openpower/scripts/release-notes
@@ -111,6 +111,7 @@ foreach my $p (@common_platforms) {
     next if $p =~ /firenze/;
     next if $p =~ /^zz$/;
     next if $p =~ /mambo/;
+    next if $p =~ /redbud/;
     $repos->{"$p-xml"} = { REPO => "http://github.com/open-power/$p-xml" ,
 			   DIR => "openpower/package/$p-xml" };
 }


### PR DESCRIPTION
The redbud platform uses the witherspoon-xml repository. There is no
redbud-xml repository so ignore it when creating a list of -xml
repositories.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1237)
<!-- Reviewable:end -->
