### PR TITLE
p8-pore-binutils: build with -Wno-error

### DIFF
--- a/openpower/package/p8-pore-binutils/p8-pore-binutils.mk
+++ b/openpower/package/p8-pore-binutils/p8-pore-binutils.mk
@@ -19,7 +19,7 @@ define HOST_P8_PORE_BINUTILS_BUILD_CMDS
                     --exec-prefix=$(P8_PORE_BINUTILS_BIN) \
                     --target=pore-elf64 && \
         make configure-host && \
-        make LDFLAGS=-all-static
+        make CFLAGS=-Wno-error LDFLAGS=-all-static
 endef
 
 define HOST_P8_PORE_BINUTILS_INSTALL_CMDS


### PR DESCRIPTION
Otherwise, with GCC7 (default on Fedora 26) we fail to build with errors
like this:

coffgen.c:1996:8: error: this statement may fall through [-Werror=implicit-fallthrough=]

Fixes: https://github.com/open-power/op-build/issues/1249
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1250)
<!-- Reviewable:end -->
