### PR TITLE
release-notes: Clone project repos via HTTPS

### DIFF
--- a/openpower/scripts/release-notes
+++ b/openpower/scripts/release-notes
@@ -13,18 +13,18 @@ my $dbh = DBI->connect($db,undef,undef, {AutoCommit => 1, RaiseError=>1});
 
 my $repos =
 {
-    'op-build' => { REPO => "http://github.com/open-power/op-build" },
-    'hostboot' => { REPO => "http://github.com/open-power/hostboot" ,
+    'op-build' => { REPO => "https://github.com/open-power/op-build" },
+    'hostboot' => { REPO => "https://github.com/open-power/hostboot" ,
                     DIR => "openpower/package/hostboot" },
-    'sbe'      => { REPO => "http://github.com/open-power/sbe" ,
+    'sbe'      => { REPO => "https://github.com/open-power/sbe" ,
                     DIR => "openpower/package/sbe"},
-    'skiboot'  => { REPO => "http://github.com/open-power/skiboot" ,
+    'skiboot'  => { REPO => "https://github.com/open-power/skiboot" ,
                     DIR => "openpower/package/skiboot"},
-    'occ'      => { REPO => "http://github.com/open-power/occ" ,
+    'occ'      => { REPO => "https://github.com/open-power/occ" ,
                     DIR => "openpower/package/occ"},
-    'pnor'     => { REPO => "http://github.com/open-power/pnor" ,
+    'pnor'     => { REPO => "https://github.com/open-power/pnor" ,
                     DIR => "openpower/package/openpower-pnor"},
-    'petitboot'     => { REPO => "http://github.com/open-power/petitboot" ,
+    'petitboot'     => { REPO => "https://github.com/open-power/petitboot" ,
 			 DIR => "openpower/package/petitboot"},
 };
 
@@ -130,7 +130,7 @@ foreach my $p (@common_platforms) {
 	    $p = "witherspoon";
 	    $witherspoon_insanity = 1;
     }
-    $repos->{"$p-xml"} = { REPO => "http://github.com/open-power/$p-xml" ,
+    $repos->{"$p-xml"} = { REPO => "https://github.com/open-power/$p-xml" ,
 			   DIR => "openpower/package/$p-xml" };
 }
 


### PR DESCRIPTION
The release-notes script currently specifies HTTP URLs for each project
repository. These are all Github URLs and recently there's been a 50/50
chance of Github either a) redirecting to HTTPS or b) timing out.

Update all URLs to use HTTPS so that the release-notes script can
actually clone them.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1347)
<!-- Reviewable:end -->
