### PR TITLE
libflash: Set SKIBOOT_VERSION for host-libflash

### DIFF
--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -30,7 +30,8 @@ define LIBFLASH_BUILD_CMDS
 endef
 
 define HOST_LIBFLASH_BUILD_CMDS
-    $(HOST_MAKE_ENV) $(MAKE) -C $(@D)/external/pflash
+    $(HOST_MAKE_ENV) SKIBOOT_VERSION=$(LIBFLASH_VERSION) \
+	    $(MAKE) -C $(@D)/external/pflash
 endef
 
 define LIBFLASH_INSTALL_STAGING_CMDS


### PR DESCRIPTION
The recent change to install host-pflash can cause the build to fail
since PFLASH_VERSION is not set:

version.c:1:2: error: #error You need to set PFLASH_VERSION environment variable
 #error You need to set PFLASH_VERSION environment variable
  ^
rules.mk:39: recipe for target 'version.o' failed

PFLASH_VERSION is set from SKIBOOT_VERSION, add it to the build command
as we do for normal libflash build command.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1385)
<!-- Reviewable:end -->
