### PR TITLE
Switch to term-on-error for mfg mode errors

### DIFF
--- a/openpower/configs/hostboot/witherspoon.config
+++ b/openpower/configs/hostboot/witherspoon.config
@@ -71,3 +71,6 @@ unset HOST_HCDB_SUPPORT
 unset CONSOLE_OUTPUT_TRACE
 set CONSOLE_OUTPUT_FFDCDISPLAY
 
+# Terminate Hostboot when errors occur in manufacturing mode
+#   (relies on BMC to not trigger reboot)
+unset HANG_ON_MFG_SRC_TERM


### PR DESCRIPTION
Change Hostboot behavior to do a regular terminate in manufacturing
mode instead of doing infinite loop since we have a BMC codestack
that supports not rebooting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1424)
<!-- Reviewable:end -->
