### PR TITLE
Disable trace debug and enable IPLTime checkstop analysis.

### DIFF
--- a/openpower/configs/hostboot/p9dsu.config
+++ b/openpower/configs/hostboot/p9dsu.config
@@ -67,9 +67,9 @@ set IPLTIME_CHECKSTOP_ANALYSIS
 # Hostboot will not detect hardware changes
 unset HOST_HCDB_SUPPORT
 
-# disable trace debug to console
+# set for trace debug to console
 unset CONSOLE_OUTPUT_TRACE
-unset CONSOLE_OUTPUT_FFDCDISPLAY
+set CONSOLE_OUTPUT_FFDCDISPLAY
 
 unset SECUREBOOT
 unset TPMDD

--- a/openpower/configs/hostboot/p9dsu.config
+++ b/openpower/configs/hostboot/p9dsu.config
@@ -59,9 +59,10 @@ unset PNOR_TWO_SIDE_SUPPORT
 
 set BMC_BT_LPC_IPMI
 
-# Disable Checktop Analysis
+# Enable Checktop Analysis for both
+# Runtime and IPLtime scenarios
 set ENABLE_CHECKSTOP_ANALYSIS
-unset IPLTIME_CHECKSTOP_ANALYSIS
+set IPLTIME_CHECKSTOP_ANALYSIS
 
 # Hostboot will not detect hardware changes
 unset HOST_HCDB_SUPPORT


### PR DESCRIPTION
Disable trace debug. Leave CONSOLE_OUTPUT_FFDCDISPLAY set.
Enable IPLTime checkstop analysis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1437)
<!-- Reviewable:end -->
