### PR TITLE
configs: Re-enable translations

### DIFF
--- a/openpower/configs/barreleye_defconfig
+++ b/openpower/configs/barreleye_defconfig
@@ -9,6 +9,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/firenze_defconfig
+++ b/openpower/configs/firenze_defconfig
@@ -8,6 +8,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/firestone_defconfig
+++ b/openpower/configs/firestone_defconfig
@@ -9,6 +9,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/garrison_defconfig
+++ b/openpower/configs/garrison_defconfig
@@ -9,6 +9,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/habanero_defconfig
+++ b/openpower/configs/habanero_defconfig
@@ -10,6 +10,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/p9dsu_defconfig
+++ b/openpower/configs/p9dsu_defconfig
@@ -9,6 +9,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/pseries_defconfig
+++ b/openpower/configs/pseries_defconfig
@@ -9,6 +9,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/romulus_defconfig
+++ b/openpower/configs/romulus_defconfig
@@ -9,6 +9,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/witherspoon-redbud_defconfig
+++ b/openpower/configs/witherspoon-redbud_defconfig
@@ -10,6 +10,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/witherspoon-sequoia_defconfig
+++ b/openpower/configs/witherspoon-sequoia_defconfig
@@ -10,6 +10,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/zaius_defconfig
+++ b/openpower/configs/zaius_defconfig
@@ -9,6 +9,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y

--- a/openpower/configs/zz_defconfig
+++ b/openpower/configs/zz_defconfig
@@ -8,6 +8,7 @@ BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"
 BR2_TARGET_GENERIC_GETTY_PORT="hvc0"
 BR2_ENABLE_LOCALE_WHITELIST="C de en es fr it ja ko pt_BR ru zh_CN zh_TW"
 BR2_GENERATE_LOCALE="en_US.UTF-8 de_DE.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 pt_BR.UTF-8 ru_RU.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_SYSTEM_ENABLE_NLS=y
 BR2_ROOTFS_OVERLAY="../openpower/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="../openpower/scripts/fixup-target-var ../openpower/scripts/firmware-whitelist"
 BR2_LINUX_KERNEL=y


### PR DESCRIPTION
The 2017.08 Buildroot update introduced a new option
"BR2_SYSTEM_ENABLE_NLS" which is by default set to false.
Set this to true in all platforms that use translations to re-enable
them.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1438)
<!-- Reviewable:end -->
