### PR TITLE
petitboot: Use linux terminal type

### DIFF
--- a/openpower/package/petitboot/petitboot-console-ui.rules
+++ b/openpower/package/petitboot/petitboot-console-ui.rules
@@ -1,5 +1,5 @@
 
 # spawn a petitboot UI on common user-visible interface devices
-SUBSYSTEM=="tty", KERNEL=="hvc*", RUN+="/usr/libexec/petitboot/pb-console --getty --detach -- -n -i 0 $name vt100"
-SUBSYSTEM=="tty", KERNEL=="tty0", RUN+="/usr/libexec/petitboot/pb-console --getty --detach -- -n -i 0 $name vt100"
-SUBSYSTEM=="tty", KERNEL=="ttyS*", RUN+="/usr/libexec/petitboot/pb-console --getty --detach -- -n -i 0 $name vt100"
+SUBSYSTEM=="tty", KERNEL=="hvc*", RUN+="/usr/libexec/petitboot/pb-console --getty --detach -- -n -i 0 $name linux"
+SUBSYSTEM=="tty", KERNEL=="tty0", RUN+="/usr/libexec/petitboot/pb-console --getty --detach -- -n -i 0 $name linux"
+SUBSYSTEM=="tty", KERNEL=="ttyS*", RUN+="/usr/libexec/petitboot/pb-console --getty --detach -- -n -i 0 $name linux"


### PR DESCRIPTION
Switching from vt100 to the linux termtype appears to solve the problem
of incorrectly displaying ncurses extended characters used for parts of
the window border. This error can occur, for example, by opening a SOL
session when the Petitboot UI is already drawn:

```
 Petitboot (v1.5.0-p60e3423)                          8335-GCA 2108ECA
 qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq

  System information
  System configuration
  System status log
  Language
  Rescan devices
  Retrieve config from URL
 *Exit to shell
 qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
 Enter=accept, e=edit, n=new, x=exit, l=language, g=log, h=help
```

Switching to 'linux' correctly draws the line borders even when starting
a session late.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1441)
<!-- Reviewable:end -->
