### PR TITLE
Save Debug Data During op-build

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -61,6 +61,18 @@ SBE_BINARY_DIR = $(STAGING_DIR)/sbe_binaries/
 OPENPOWER_PNOR_SCRATCH_DIR = $(STAGING_DIR)/openpower_pnor_scratch/
 OPENPOWER_VERSION_DIR = $(STAGING_DIR)/openpower_version
 OPENPOWER_MRW_SCRATCH_DIR = $(STAGING_DIR)/openpower_mrw_scratch
+OUTPUT_BUILD_DIR = $(STAGING_DIR)/../../../build/
+OUTPUT_IMAGES_DIR = $(STAGING_DIR)/../../../images/
+HOSTBOOT_BUILD_IMAGES_DIR = $(STAGING_DIR)/../../../staging/hostboot_build_images/
+
+FILES_TO_TAR = $(HOSTBOOT_BUILD_IMAGES_DIR)/* \
+               $(OUTPUT_BUILD_DIR)/skiboot-*/skiboot.elf \
+               $(OUTPUT_BUILD_DIR)/skiboot-*/skiboot.map \
+               $(OUTPUT_BUILD_DIR)/linux-*/.config \
+               $(OUTPUT_BUILD_DIR)/linux-*/vmlinux \
+               $(OUTPUT_BUILD_DIR)/linux-*/System.map \
+               $(OUTPUT_IMAGES_DIR)/zImage.epapr
+
 
 # Subpackages we want to include in the version info (do not include openpower-pnor)
 OPENPOWER_VERSIONED_SUBPACKAGES = skiboot hostboot linux petitboot machine-xml occ hostboot-binaries capp-ucode
@@ -133,6 +145,9 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             PATH=$(HOST_DIR)/usr/bin:$(PATH) $(HOST_DIR)/usr/bin/generate-squashfs -f $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME).squashfs.tar $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME); \
             $(INSTALL) $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME).squashfs.tar $(BINARIES_DIR); \
         fi
+
+	    tar --transform 's/.*\///g' -zcvf $(OUTPUT_IMAGES_DIR)/host_fw_debug.tar $(FILES_TO_TAR)
+
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
op-build will now make a tar archive of the files useful for debugging.
The full list of files:
-hbicore.bin.modinfo
-hbicore.list.bz2
-hbicore.syms
-hbirt.bin.modinfo
-hbirt.list.bz2
-hbirt.syms
-hbotStringFile
-ecmd-debug-framework.pl
-skiboot.elf
-skiboot.map
-.config
-vmlinux
-System.map
-zImage.epapr

RTC:126574

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/op-build/1446)
<!-- Reviewable:end -->
