### PR TITLE
Add unit nodes for nvlink in P9 DTS files

### DIFF
--- a/openpower/package/ima-catalog/ima-catalog.mk
+++ b/openpower/package/ima-catalog/ima-catalog.mk
@@ -3,7 +3,7 @@
 # ima-catalog.mk
 #
 ################################################################################
-IMA_CATALOG_VERSION ?= f9da5d6feb3c407cd24c88d61b73d7d01b2d1400
+IMA_CATALOG_VERSION ?= 7c7a388ae0bb734cc9e4fe10593c45d8946a8fd7
 IMA_CATALOG_SITE ?= $(call github,open-power,ima-catalog,$(IMA_CATALOG_VERSION))
 IMA_CATALOG_LICENSE = Apache-2.0
 IMA_CATALOG_DEPENDENCIES = host-dtc host-xz


### PR DESCRIPTION
- Unit nodes for NVLink added for consistency

Signed-off-by: Raj <drajarshi@in.ibm.com>