### PR TITLE
libflash: Update to upstream version v5.8-123-gc06ed583

### DIFF
--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBFLASH_VERSION = v5.7-76-g830fc9a0ed0a
+LIBFLASH_VERSION = v5.8-123-gc06ed583
 LIBFLASH_SITE = $(call github,open-power,skiboot,$(LIBFLASH_VERSION))
 
 LIBFLASH_INSTALL_STAGING = YES


### PR DESCRIPTION
Update libflash to the latest upstream commit, in particular to pick up
the commit "pflash: Fix erase command for unaligned start address",
which fixes an issue resulting in incomplete erases.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>