### PR TITLE
Removed the HOST_HCDB_SUPPORT directive

### DIFF
--- a/openpower/configs/hostboot/p9dsu.config
+++ b/openpower/configs/hostboot/p9dsu.config
@@ -63,9 +63,6 @@ set BMC_BT_LPC_IPMI
 set ENABLE_CHECKSTOP_ANALYSIS
 unset IPLTIME_CHECKSTOP_ANALYSIS
 
-# Hostboot will not detect hardware changes
-unset HOST_HCDB_SUPPORT
-
 # set for trace debug to console
 set CONSOLE_OUTPUT_TRACE
 set CONSOLE_OUTPUT_FFDCDISPLAY

--- a/openpower/configs/hostboot/romulus.config
+++ b/openpower/configs/hostboot/romulus.config
@@ -60,9 +60,6 @@ set BMC_BT_LPC_IPMI
 unset ENABLE_CHECKSTOP_ANALYSIS
 unset IPLTIME_CHECKSTOP_ANALYSIS
 
-# Hostboot will detect hardware changes
-unset HOST_HCDB_SUPPORT
-
 # set for trace debug to console
 set CONSOLE_OUTPUT_TRACE
 

--- a/openpower/configs/hostboot/witherspoon.config
+++ b/openpower/configs/hostboot/witherspoon.config
@@ -64,9 +64,6 @@ set BMC_BT_LPC_IPMI
 set ENABLE_CHECKSTOP_ANALYSIS
 set IPLTIME_CHECKSTOP_ANALYSIS
 
-# Hostboot will not detect hardware changes
-unset HOST_HCDB_SUPPORT
-
 # set for trace debug to console
 unset CONSOLE_OUTPUT_TRACE
 set CONSOLE_OUTPUT_FFDCDISPLAY

--- a/openpower/configs/hostboot/zaius.config
+++ b/openpower/configs/hostboot/zaius.config
@@ -63,9 +63,6 @@ set BMC_BT_LPC_IPMI
 set ENABLE_CHECKSTOP_ANALYSIS
 set IPLTIME_CHECKSTOP_ANALYSIS
 
-# Hostboot will not detect hardware changes
-unset HOST_HCDB_SUPPORT
-
 # set for trace debug to console
 unset CONSOLE_OUTPUT_TRACE
 set CONSOLE_OUTPUT_FFDCDISPLAY


### PR DESCRIPTION
Removed the HOST_HCDB_SUPPORT directive from the config file. It
will now be controlled from the hwas/HBconfig file.