### PR TITLE
Bump openpower-ffs to e99543bb1729c76044f6fdd0d24a2fec5d543177

### DIFF
--- a/openpower/package/openpower-ffs/openpower-ffs.mk
+++ b/openpower/package/openpower-ffs/openpower-ffs.mk
@@ -1,17 +1,9 @@
-OPENPOWER_FFS_VERSION ?= 2e790b8409071ca15767d822dabfa8e60f12c6e2
+OPENPOWER_FFS_VERSION ?= 3ec70fbc458e32eef0d0b1de79688b4dc48cbd57
 OPENPOWER_FFS_SITE ?= $(call github,open-power,ffs,$(OPENPOWER_FFS_VERSION))
-OPENPOWER_FFS_LICENSE = GPLv2+
+OPENPOWER_FFS_LICENSE = Apache-2.0
 OPENPOWER_FFS_LICENSE_FILES = LICENSE
 
-define HOST_OPENPOWER_FFS_BUILD_CMDS
-	cd $(@D) ; \
-	$(HOST_MAKE_ENV) $(MAKE) all
-endef
+OPENPOWER_FFS_AUTORECONF = YES
+OPENPOWER_FFS_AUTORECONF_OPTS = -i
 
-define HOST_OPENPOWER_FFS_INSTALL_CMDS
-	$(INSTALL) -D $(@D)/ecc/x86/ecc $(HOST_DIR)/usr/bin/ecc
-	$(INSTALL) -D $(@D)/fpart/x86/fpart $(HOST_DIR)/usr/bin/fpart
-	$(INSTALL) -D $(@D)/fcp/x86/fcp $(HOST_DIR)/usr/bin/fcp
-endef
-
-$(eval $(host-generic-package))
+$(eval $(host-autotools-package))


### PR DESCRIPTION
Christian Geddes (1):
      Update libffs to increment part entry and TOC size info

Stewart Smith (40):
          add .travis.yml for travis-ci
          add running of fpart test to travis
          Remove unused memory_leak_detection.h
          remove unused table and table_iter
          remove unused bitset
          remove unused map and map_iter
          remove unused timer.h
          remove unused vector and vector_iter
          remove unused stack.h
          remove unused dispatch and watch
          remove unused array
          remove unused heap
          remove unused signal
          remove unused db.c/db.h
          remove unused slab
          remove more unused memory_leak_detection code
          remove crc32 - use sha1sum in test case instead
          remove likely/unlikely: nothing is *that* perf critical
          Remove #define parity __builtin_parity
          remove unused ctz builtin defines
          Move to autotools
          remove custom assert implementation and exception.c
          Update travis-ci.yml for autotools
          remove autoconf 2.69 requiremnt
          remove AC_CHECK_HEADER_STDBOOL
          remove unused mq
          use trusty travis env
          Fix make distcheck
          use open/read/write for create_regular_file
          Don't use fsync(): it's not needed
          fpart/libffs doesn't initialized reserved FFS header to 0
          Add .gitignore
          Merge fix for TOC > 4k
          Add skeleton README
          Merge branch 'bugfixes' of https://github.com/stewart-ibm/ffs
          fpart: make test run valgrind clean
          fix high memory usage during any operation with '--buffer'
          Remove references to removed clib/assert.h
          clib: include system assert.h
          README: add build instructions
