### PR TITLE
skiroot_p9_defconfig: Enable powersave in Petitboot kernel

### DIFF
--- a/openpower/configs/linux/skiroot_p9_defconfig
+++ b/openpower/configs/linux/skiroot_p9_defconfig
@@ -50,7 +50,7 @@ CONFIG_NUMA=y
 CONFIG_PPC_64K_PAGES=y
 CONFIG_SCHED_SMT=y
 CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="console=tty0 console=hvc0 powersave=off"
+CONFIG_CMDLINE="console=tty0 console=hvc0"
 # CONFIG_SECCOMP is not set
 CONFIG_NET=y
 CONFIG_PACKET=y


### PR DESCRIPTION
i.e. let's die in a horrific fire if stop states aren't working
correctly.

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>