### PR TITLE
linux/defconfig: Set ipr.fast_reboot=1

### DIFF
--- a/openpower/configs/linux/skiroot_defconfig
+++ b/openpower/configs/linux/skiroot_defconfig
@@ -50,7 +50,7 @@ CONFIG_NUMA=y
 CONFIG_PPC_64K_PAGES=y
 CONFIG_SCHED_SMT=y
 CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="console=tty0 console=hvc0 quiet"
+CONFIG_CMDLINE="console=tty0 console=hvc0 ipr.fast_reboot=1 quiet"
 # CONFIG_SECCOMP is not set
 CONFIG_NET=y
 CONFIG_PACKET=y

--- a/openpower/configs/linux/skiroot_p9_defconfig
+++ b/openpower/configs/linux/skiroot_p9_defconfig
@@ -50,7 +50,7 @@ CONFIG_NUMA=y
 CONFIG_PPC_64K_PAGES=y
 CONFIG_SCHED_SMT=y
 CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="console=tty0 console=hvc0 powersave=off"
+CONFIG_CMDLINE="console=tty0 console=hvc0 ipr.fast_reboot=1 powersave=off"
 # CONFIG_SECCOMP is not set
 CONFIG_NET=y
 CONFIG_PACKET=y


### PR DESCRIPTION
This makes booting an OS on a machine with an IPR adapter a
lot quicker, avoiding a lot of reset time.

Suggested-by: Brian King <brking@linux.vnet.ibm.com>
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>