### PR TITLE
gcc: disable libsanitizer

### DIFF
--- a/openpower/configs/barreleye_defconfig
+++ b/openpower/configs/barreleye_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/firenze_defconfig
+++ b/openpower/configs/firenze_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"

--- a/openpower/configs/firestone_defconfig
+++ b/openpower/configs/firestone_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/garrison_defconfig
+++ b/openpower/configs/garrison_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/habanero_defconfig
+++ b/openpower/configs/habanero_defconfig
@@ -2,7 +2,7 @@ BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/habanero-patches"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/openpower_mambo_defconfig
+++ b/openpower/configs/openpower_mambo_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"

--- a/openpower/configs/openpower_p9_mambo_defconfig
+++ b/openpower/configs/openpower_p9_mambo_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot-p9"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"

--- a/openpower/configs/p9dsu_defconfig
+++ b/openpower/configs/p9dsu_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/palmetto_defconfig
+++ b/openpower/configs/palmetto_defconfig
@@ -2,7 +2,7 @@ BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/palmetto-patches"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/pseries_defconfig
+++ b/openpower/configs/pseries_defconfig
@@ -2,7 +2,7 @@ BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_VERSION_2_27_X=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"

--- a/openpower/configs/romulus_defconfig
+++ b/openpower/configs/romulus_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/witherspoon_defconfig
+++ b/openpower/configs/witherspoon_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/zaius_defconfig
+++ b/openpower/configs/zaius_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y

--- a/openpower/configs/zz_defconfig
+++ b/openpower/configs/zz_defconfig
@@ -1,7 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
-BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 BR2_ROOTFS_DEVICE_TABLE="../openpower/device_table.txt"


### PR DESCRIPTION
GCC builds this library in order to enable the -fsanitize error detection
features. This part of the compile takes several minutes on a Westmere
Xeon build server, and to make it worse the build serialises at that
point.

Our GCC is 6.4 at this point. Running 'op-build toolchain' shows a
saving of about 33% (4 minutes) on a 40 core machine and a 25% (6
minutes) on a 2 core machine.

We build neither the kernel nor userspace with any of these tools, and
probably never will in production.

In order to save build time disable libsantizer for GCC builds.

Signed-off-by: Joel Stanley <joel@jms.id.au>