### PR TITLE
Bump libflash to v5.10.1

### DIFF
--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBFLASH_VERSION = v5.9-166-g70f14f4dd86e
+LIBFLASH_VERSION = v5.10.1
 LIBFLASH_SITE = $(call github,open-power,skiboot,$(LIBFLASH_VERSION))
 
 LIBFLASH_INSTALL_STAGING = YES


### PR DESCRIPTION
Not all of these are applicable to libflash/pflash as we use them,
but this gets us onto the latest release.

Cyril Bur (11):
      libflash/mbox-flash: Always close windows before opening a new window
      libflash/mbox-flash: Move sequence handling to driver level
      libflash/mbox-flash: Allow mbox-flash to tell the driver msg timeouts
      libflash/mbox-flash: Simplify message sending
      libflash/mbox-flash: Use BMC suggested timeout value
      libflash/mbox-flash: Use static arrays of function pointers
      libflash/mbox-flash: Understand v3
      libflash/mbox-flash: Add the ability to lock flash
      libflash/test: Add tests for mbox-flash
      pflash: Respect write(2) return values
      libflash/blocklevel: Correct miscalculation in blocklevel_smart_erase()

Frédéric Bonnard (1):
      Add man pages for xscom-utils and pflash

Stewart Smith (3):
      libflash/mbox-flash: only wait for MBOX_DEFAULT_POLL_MS if busy
      libflash/mbox-flash: fallback to requesting lower MBOX versions from BMC
      pflash: Fix makefile dependency issue

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>