### PR TITLE
Add capp ucode for P9-DD2.3

### DIFF
--- a/openpower/package/capp-ucode/capp-ucode.mk
+++ b/openpower/package/capp-ucode/capp-ucode.mk
@@ -3,7 +3,7 @@
 # capp-ucode.mk
 #
 ################################################################################
-CAPP_UCODE_VERSION ?= p9-dd2-v3
+CAPP_UCODE_VERSION ?= p9-dd2-v4
 CAPP_UCODE_SITE ?= $(call github,open-power,capp-ucode,$(CAPP_UCODE_VERSION))
 CAPP_UCODE_LICENSE = Apache-2.0
 CAPP_UCODE_LICENSE_FILES = NOTICES


### PR DESCRIPTION
Point the capp-ucode.mk to latest capp-ucode tagged release for POWER9
DD-2.3 chip.

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>