### PR TITLE
openpower: Add msglog tool to skiroot

### DIFF
--- a/openpower/overlay/bin/msglog
+++ b/openpower/overlay/bin/msglog
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec cat /sys/firmware/opal/msglog


### PR DESCRIPTION
This adds a one line shell script that can be used to display the OPAL
msglog without having to type out the full path.

Signed-off-by: Joel Stanley <joel@jms.id.au>