### PR TITLE
buildroot: Move to 2018.05 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "buildroot"]
 	path = buildroot
-	branch = 2018.02-op-build
+	branch = 2018.05-op-build
 	url = https://github.com/open-power/buildroot

--- a/openpower/configs/barreleye_defconfig
+++ b/openpower/configs/barreleye_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/firenze_defconfig
+++ b/openpower/configs/firenze_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"

--- a/openpower/configs/firestone_defconfig
+++ b/openpower/configs/firestone_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/garrison_defconfig
+++ b/openpower/configs/garrison_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/habanero_defconfig
+++ b/openpower/configs/habanero_defconfig
@@ -1,6 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/habanero-patches"
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/openpower_mambo_defconfig
+++ b/openpower/configs/openpower_mambo_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"

--- a/openpower/configs/openpower_p9_mambo_defconfig
+++ b/openpower/configs/openpower_p9_mambo_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot-p9"

--- a/openpower/configs/p9dsu_defconfig
+++ b/openpower/configs/p9dsu_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/palmetto_defconfig
+++ b/openpower/configs/palmetto_defconfig
@@ -1,6 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/palmetto-patches"
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/pseries_defconfig
+++ b/openpower/configs/pseries_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"

--- a/openpower/configs/romulus_defconfig
+++ b/openpower/configs/romulus_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/vesnin_defconfig
+++ b/openpower/configs/vesnin_defconfig
@@ -1,6 +1,7 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/vesnin-patches"
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/witherspoon_defconfig
+++ b/openpower/configs/witherspoon_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/witherspoon_dev_defconfig
+++ b/openpower/configs/witherspoon_dev_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/zaius_defconfig
+++ b/openpower/configs/zaius_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/configs/zz_defconfig
+++ b/openpower/configs/zz_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_16=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TARGET_GENERIC_HOSTNAME="skiroot"


### PR DESCRIPTION
 https://git.buildroot.net/buildroot/plain/CHANGES?id=2018.05
 http://lists.busybox.net/pipermail/buildroot/2018-June/222697.html

Highlights for OpenPower Firmware:

 - Buildroot GCC default moves to 7: We're stuck on GCC 6 due to Hostboot :(

 - Git caching: you don't need to re-clone from scratch when moving to a
 different version of a package

Updated packages:

  busybox: 1.27.2 -> 1.28.4
  glibc: glibc-2.26-146 -> glibc-2.27-57
  dropbear: 2017.75 -> 2018.76
  ethtool: 4.13 -> 4.16
  ncurses: 6.0 -> 6.1
  util-linux: 2.31.1 -> 2.32

Updated host packages:

  lz4: v1.7.5 -> v1.8.2
  ncurses: 6.0 -> 6.1
  gcc-initial: 6.4.0 -> 7.3.0
  gcc-final: 6.4.0 -> 7.3.0
  lzip: 1.19 -> 1.20
  gawk: 4.1.4 -> 4.2.1
  libopenssl: 1.0.2n -> 1.0.2o
  squashfs: 3de1687d7432ea9b302c2db9521996f506c140a3 -> e38956b92f738518c29734399629e7cdb33072d3

Signed-off-by: Joel Stanley <joel@jms.id.au>