### PR TITLE
openpower-pnor: Add path nside debug object tarball

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -167,7 +167,7 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             $(INSTALL) $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME).squashfs.tar $(BINARIES_DIR); \
         fi
 
-	    tar --transform 's/.*\///g' -zcvf $(OUTPUT_IMAGES_DIR)/host_fw_debug.tar $(FILES_TO_TAR)
+	    tar --transform 's/.*\//host_fw_debug/g' -zcvf $(OUTPUT_IMAGES_DIR)/host_fw_debug.tar $(FILES_TO_TAR)
 
 endef
 


### PR DESCRIPTION
So that when you untar them you don't end up with a heap of files in
your current working directory.

Signed-off-by: Joel Stanley <joel@jms.id.au>