### PR TITLE
Updates to CI scripts

### DIFF
--- a/ci/build-all-defconfigs.sh
+++ b/ci/build-all-defconfigs.sh
@@ -36,6 +36,7 @@ if [ -n "$DL_DIR" ]; then
 fi
 
 for i in ${DEFCONFIGS[@]}; do
+        rm -rf output/*
         op-build $i
         echo 'BR2_CCACHE=y' >> output/.config
         echo "BR2_CCACHE_DIR=\"$CCACHE_DIR\"" >> output/.config
@@ -48,7 +49,6 @@ for i in ${DEFCONFIGS[@]}; do
         mv output/images/* $1/$i-images/
         mv output/.config $1/$i-images/.config
 	lsb_release -a > $1/$i-images/lsb_release
-        rm -rf output/*
         if [ $r -ne 0 ]; then
         	exit $r
         fi

--- a/ci/build-all-defconfigs.sh
+++ b/ci/build-all-defconfigs.sh
@@ -3,22 +3,48 @@
 set -ex
 set -eo pipefail
 
+BUILD_INFO=0
 CONFIGTAG="_defconfig"
 
 DEFCONFIGS=();
 
-if [ -z "$2" ]; then
+while getopts "o:p:r" opt; do
+  case $opt in
+    o)
+      echo "Output directory: $OPTARG"
+      OUTDIR="$OPTARG"
+      ;;
+    p)
+      echo "Platforms to build: $OPTARG"
+      PLATFORM_LIST="$OPTARG"
+      ;;
+    r)
+      echo "Build legal-info for release"
+      BUILD_INFO=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG"
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument."
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${PLATFORM_LIST}" ]; then
         echo "Using all the defconfigs for all the platforms"
         DEFCONFIGS=`(cd openpower/configs; ls -1 *_defconfig)`
 else
         IFS=', '
-        for p in $2;
+        for p in ${PLATFORM_LIST};
         do
                 DEFCONFIGS+=($p$CONFIGTAG)
         done
 fi
 
-if [ -z "$1" or ! -d "$1" ]; then
+if [ -z "${OUTDIR}" or ! -d "${OUTDIR}" ]; then
 	echo "No output directory specified"
 	exit 1;
 fi
@@ -45,10 +71,16 @@ for i in ${DEFCONFIGS[@]}; do
         op-build olddefconfig
         op-build
         r=$?
-        mkdir $1/$i-images
-        mv output/images/* $1/$i-images/
-        mv output/.config $1/$i-images/.config
-	lsb_release -a > $1/$i-images/lsb_release
+
+        if [ ${BUILD_INFO} = 1 ] && [ $r = 0 ]; then
+                op-build legal-info
+                mv output/legal-info ${OUTDIR}/$i-legal-info
+        fi
+
+        mkdir ${OUTDIR}/$i-images
+        mv output/images/* ${OUTDIR}/$i-images/
+        mv output/.config ${OUTDIR}/$i-images/.config
+        lsb_release -a > ${OUTDIR}/$i-images/lsb_release
         if [ $r -ne 0 ]; then
         	exit $r
         fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -2,7 +2,7 @@
 
 CONTAINERS="ubuntu1604 fedora27"
 
-while getopts ":ab:hp:c:" opt; do
+while getopts ":ab:hp:c:r" opt; do
   case $opt in
     a)
       echo "Build firmware images for all the platforms"
@@ -31,6 +31,10 @@ while getopts ":ab:hp:c:" opt; do
       echo -e "\tDOCKER_PREFIX=sudo ./ci/build.sh -p firestone"
       echo -e "\tDOCKER_PREFIX=sudo ./ci/build.sh -p garrison,palmetto,openpower_p9_mambo"
       exit 1
+      ;;
+    r)
+      echo "Build for release"
+      release_args="-r"
       ;;
     \?)
       echo "Invalid option: -$OPTARG"
@@ -107,7 +111,7 @@ EOF
 )
 	$DOCKER_PREFIX docker build --network=host -t openpower/op-build-$distro - <<< "${Dockerfile}"
 	mkdir -p output-images/$distro
-	run_docker openpower/op-build-$distro "./ci/build-all-defconfigs.sh output-images/$distro $PLATFORMS"
+	run_docker openpower/op-build-$distro "./ci/build-all-defconfigs.sh -o output-images/$distro -p $PLATFORMS ${release_args}"
 	if [ $? = 0 ]; then
 		mv *-images output-$distro/
 	else


### PR DESCRIPTION
Tweak where `build-all-defconfigs.sh` cleans up its output directory to make post-build processing and/or debugging easier, and add an option to generate the `legal-info` target during the build.