### PR TITLE
Enable host_fw_debug.tar file to keep file structure

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -167,7 +167,10 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             $(INSTALL) $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME).squashfs.tar $(BINARIES_DIR); \
         fi
 
-	    tar --transform 's/.*\//host_fw_debug/g' -zcvf $(OUTPUT_IMAGES_DIR)/host_fw_debug.tar $(FILES_TO_TAR)
+	#Create Debug Tarball
+	mkdir -p $(STAGING_DIR)/pnor/host_fw_debug_tarball_files/
+	cp -r $(FILES_TO_TAR) $(STAGING_DIR)/pnor/host_fw_debug_tarball_files/
+	tar -zcvf $(OUTPUT_IMAGES_DIR)/host_fw_debug.tar -C $(STAGING_DIR)/pnor/host_fw_debug_tarball_files/  .
 
 endef
 


### PR DESCRIPTION
  - The HB tools were losing their file structure,
    which caused commands like ecmd-debug-framework
    to fail as the required perl modules were not
    in the expected location