### PR TITLE
Add bsdmainutils to Ubuntu docker

### DIFF
--- a/ci/Dockerfile/ubuntu1604
+++ b/ci/Dockerfile/ubuntu1604
@@ -7,4 +7,4 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   build-essential g++ git bison flex unzip \
   cpio vim-common lsb-release \
   libxml-simple-perl libxml-sax-perl libxml2-dev libxml2-utils xsltproc \
-  wget bc libssl-dev python-matplotlib python-numpy graphviz eatmydata
+  wget bc libssl-dev python-matplotlib python-numpy graphviz eatmydata bsdmainutils


### PR DESCRIPTION
The docker image of Ubuntu 16.04 doesn't have 'colrm' utility which is
used in Perl script 'addimgid' (hostboot build tools) to construct an ID string
of hostboot image:
https://github.com/open-power/hostboot/blob/master/src/build/tools/addimgid#L39
As result, variable hbi_ImageId in hostboot is allways empty.
Installing bsdmainutils package resolves this problem.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>