### PR TITLE
docs: Force sphinx to be version 1.7.9

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
-sphinx
+# Pinned due to https://github.com/sphinx-doc/sphinx/issues/5419
+sphinx==1.7.9
 recommonmark


### PR DESCRIPTION
The latest release (1.8) contains a bug when building the latex output.
Pin the version to 1.7.9 while we wait for a fix.

Upstream bug: https://github.com/sphinx-doc/sphinx/issues/5419

Signed-off-by: Joel Stanley <joel@jms.id.au>