### PR TITLE
Minor updates to support a signed VERSION partition

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -149,7 +149,7 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -targeting_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME) \
             -wofdata_binary_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/$(BR2_WOFDATA_BINARY_FILENAME) \
             -memddata_binary_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/$(BR2_MEMDDATA_BINARY_FILENAME) \
-            -openpower_version_filename $(OPENPOWER_PNOR_VERSION_FILE)
+            -openpower_version_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/openpower_pnor_version.bin
 
         $(INSTALL) $(STAGING_DIR)/pnor/$(BR2_OPENPOWER_PNOR_FILENAME) $(BINARIES_DIR)
 

--- a/openpower/package/openpower-vpnor/openpower-vpnor.mk
+++ b/openpower/package/openpower-vpnor/openpower-vpnor.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HOST_OPENPOWER_VPNOR_VERSION ?= 643e730e3b9818bdd878eebee209b268c234fc65
+HOST_OPENPOWER_VPNOR_VERSION ?= c39d923fee581533775e37be3f59f77c021718ee
 HOST_OPENPOWER_VPNOR_SITE ?= $(call github,openbmc,openpower-pnor-code-mgmt,$(HOST_OPENPOWER_VPNOR_VERSION))
 HOST_OPENPOWER_VPNOR_DEPENDENCIES = host-squashfs host-libflash
 


### PR DESCRIPTION
Updates the VERSION intermediate file location and updates openpower-vpnor such that it can handle a signed VERSION partition when generating its MANIFEST file.

Depends on https://github.com/open-power/op-build/pull/2393