### PR TITLE
Add Supprt for P9 Attribute/Targeting Read/Write Partition

### DIFF
--- a/openpower/package/hostboot-p8/hostboot-p8.mk
+++ b/openpower/package/hostboot-p8/hostboot-p8.mk
@@ -3,7 +3,7 @@
 # hostboot for POWER8
 #
 ################################################################################
-HOSTBOOT_P8_VERSION ?= 92e482dc468490502ab431663eb46d4f025913ea
+HOSTBOOT_P8_VERSION ?= c35645e2d863e37a4356d141713e082505c51e94
 
 HOSTBOOT_P8_SITE ?= $(call github,open-power,hostboot,$(HOSTBOOT_P8_VERSION))
 

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OPENPOWER_PNOR_VERSION ?= 943edddbcee702b097ef8b799115814b89797d57
+OPENPOWER_PNOR_VERSION ?= bc3b80258c3ae936246c5cc04923665e820fb05e
 OPENPOWER_PNOR_SITE ?= $(call github,open-power,pnor,$(OPENPOWER_PNOR_VERSION))
 
 OPENPOWER_PNOR_LICENSE = Apache-2.0
@@ -115,6 +115,10 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -hcode_dir $(HCODE_STAGING_DIR) \
             -targeting_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME) \
             -targeting_binary_source $(BR2_OPENPOWER_TARGETING_BIN_FILENAME) \
+            -targeting_RO_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME).protected \
+            -targeting_RO_binary_source $(BR2_OPENPOWER_TARGETING_BIN_FILENAME).protected \
+            -targeting_RW_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME).unprotected \
+            -targeting_RW_binary_source $(BR2_OPENPOWER_TARGETING_BIN_FILENAME).unprotected \
             -sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME) \
             -sbe_binary_dir $(SBE_BINARY_DIR) \
             -sbec_binary_filename $(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) \
@@ -147,6 +151,8 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -wink_binary_filename $(BR2_HOSTBOOT_BINARY_WINK_FILENAME) \
             -occ_binary_filename $(OCC_STAGING_DIR)/$(OCC_BIN_FILENAME) \
             -targeting_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME) \
+            -targeting_RO_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME).protected \
+            -targeting_RW_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME).unprotected \
             -wofdata_binary_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/$(BR2_WOFDATA_BINARY_FILENAME) \
             -memddata_binary_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/$(BR2_MEMDDATA_BINARY_FILENAME) \
             -openpower_version_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/openpower_pnor_version.bin


### PR DESCRIPTION
This commit adds support for an attribute/targeting Read-Write partition
called HBD_RW ("HB_DATA_RW") in P8 OpenPower systems. The P8 PNOR XML
Layout files had this partiontion added, while the P9 PNOR XML Layout files
did not.  The common PNOR files update_image.pl and create_pnor_image.pl
were udpated to handle whether or not HBD_RW was part of the layout.
The hostboot-p8 code (via the hostboot 'master-p8' branch) was also updated
to handle this new HBD_RW PNOR partition.