### PR TITLE
Pull in P8 PNOR XML Layout Fix for HBD/HBD_RW Partitions

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OPENPOWER_PNOR_VERSION ?= bc3b80258c3ae936246c5cc04923665e820fb05e
+OPENPOWER_PNOR_VERSION ?= aa94a39eb470d1a50138f4d0b04a5a135c4431ff
 OPENPOWER_PNOR_SITE ?= $(call github,open-power,pnor,$(OPENPOWER_PNOR_VERSION))
 
 OPENPOWER_PNOR_LICENSE = Apache-2.0


### PR DESCRIPTION
This commit pulls in an update to the P8 PNOR XML Layout files
that were causing build problems for the VESNIN configuration.  The
change is that the combined size of the HBD and HBD_RW partitions
was redistributed to HBD and HBD_RW to allow for the fact that for
P8 systems there was much more read-only attribute/targeting content
then read-write content.

Signed-off-by: Mike Baiocchi <mbaiocch@us.ibm.com>