### PR TITLE
pflash and libflash: bump to v6.2-rc1

### DIFF
--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBFLASH_VERSION = v5.10.1
+LIBFLASH_VERSION = v6.2-rc1
 LIBFLASH_SITE = $(call github,open-power,skiboot,$(LIBFLASH_VERSION))
 
 LIBFLASH_INSTALL_STAGING = YES


### PR DESCRIPTION
Previously we were based off skiboot v5.10.1, let's bump things
up to where we're going to do the next skiboot release from.

Rough changelog (for libflash/ and external/pflash/ in skiboot):

Adriana Kobylak (1):
      pflash: Add --skip option for reading

Andrew Jeffery (11):
      libflash: Add ipmi-hiomap
      astbmc: Prefer ipmi-hiomap for PNOR access
      platform: Restructure bmc_platform type
      libflash/ipmi-hiomap: Cleanup allocation on init failure
      libflash/ipmi-hiomap: Improve event handling
      libflash/ipmi-hiomap: Restore window state on window/protocol reset
      libflash/ipmi-hiomap: Use error codes rather than abort()
      libflash/test: Rewrite Makefile.check to improve scalability
      libflash/ipmi-hiomap: Fix argument type warning on x86-64
      libflash/ipmi-hiomap: Add support for unit tests
      libflash/ipmi-hiomap: Respect daemon presence and flash control

Balbir singh (3):
      mbox/flash: Remove dead code
      libflash/blocklevel_write: Fix missing error handling
      libflash/blocklevel.c: Remove unused store to ecc_len

Cyril Bur (19):
      libflash/blocklevel: Correct miscalculation in blocklevel_smart_erase()
      mbox: Harden against BMC daemon errors
      mbox: Reduce default BMC timeouts
      libffs: Standardise ffs partition flags
      external/pflash: Use ffs_entry_user_to_string() to standardise flag strings
      libflash/libffs: Add setter for a partitions actual size
      libflash/libffs: ffs_close() should use ffs_hdr_free()
      libflash/libffs: Always add entries to the end of the TOC
      libflash/libffs: Remove the 'sides' from the FFS TOC generation code
      libflash/libffs: Remove backup partition from TOC generation code
      libflash/libffs: Switch to storing header entries in an array
      libflash/libffs: Refcount ffs entries
      libflash/libffs: Allow caller to specifiy header partition
      external/ffspart: Use new interface
      libffs: Fix bad checks for partition overlap
      libflash/ecc: Add functions to deal with unaligned ECC memcpy
      libflash/ecc: Add helpers to align a position within an ecc buffer
      libflash/blocklevel: Return region start from ecc_protected()
      libflash/blocklevel: Make read/write be ECC agnostic for callers

Joel Stanley (2):
      libflash/ecc: Remove hand rolled parity asm
      pflash: Use correct prefix when installing

Nicholas Piggin (1):
      build: use thin archives rather than incremental linking

Pridhiviraj Paidipeddi (1):
      libflash/blocklevel: Add missing newline to debug messages

Stewart Smith (5):
      libflash: fix gcov build
      libflash: quieten our logging
      hiomap: free ipmi message in callback
      hiomap: fix missing newline at end of 'Flushing writes' prlog()
      hiomap: quieten warning on failing to move a window

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>