### PR TITLE
libflash from skiboot v6.2

### DIFF
--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBFLASH_VERSION = v6.2-rc1
+LIBFLASH_VERSION = v6.2
 LIBFLASH_SITE = $(call github,open-power,skiboot,$(LIBFLASH_VERSION))
 
 LIBFLASH_INSTALL_STAGING = YES


### PR DESCRIPTION
    libflash from skiboot v6.2
    
    Samuel Mendoza-Jonas (2):
          libflash: Restore blocklevel tests
          libflash: Don't merge ECC-protected ranges
    
    Stewart Smith (1):
          libflash/file: greatly increase perf of file_erase()
    
    Signed-off-by: Stewart Smith <stewart@linux.ibm.com>
