### PR TITLE
Add op-test-framework v0.13 as a git-submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = buildroot
 	branch = 2018.08-op-build
 	url = https://github.com/open-power/buildroot
+[submodule "op-test"]
+	path = op-test
+	url = https://github.com/open-power/op-test-framework.git


### PR DESCRIPTION
The idea is we tie an op-build commit to a op-test commit so that we
control what tests people run in CI via code in op-build repo rather
than random jenkins jobs.

It's also a point that an op-build commit should (must!) pass the tests
in the given op-test commit.

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>