### PR TITLE
buildroot: Pull in fix for LINUX_FIRMWARE_QLOGIC_4X

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "buildroot"]
 	path = buildroot
-	branch = 2018.08-op-build
+	branch = 2018.11-op-build
 	url = https://github.com/open-power/buildroot


### PR DESCRIPTION
This updates linux-firmware package to pull in all firmware versions for
QLOGIC 4X ("qed"). This firmware is used by Vensin.

Signed-off-by: Joel Stanley <joel@jms.id.au>