### PR TITLE
vesnin: Add temperature sensor support for CPU cores

### DIFF
--- a/openpower/patches/vesnin-patches/occ-p8/occ-0002-Add-temperature-sensor-support-for-CPU-cores.patch
+++ b/openpower/patches/vesnin-patches/occ-p8/occ-0002-Add-temperature-sensor-support-for-CPU-cores.patch
@@ -1,0 +1,43 @@
+From 0ec6ab11dcec304876802d1ed7bb01bd059ae311 Mon Sep 17 00:00:00 2001
+From: Artem Senichev <a.senichev@yadro.com>
+Date: Tue, 18 Dec 2018 14:16:56 +0300
+Subject: [PATCH] Add temperature sensor support for CPU cores
+
+IPMI protocol imposes limits on numbers of sensors identifiers (1 byte).
+This limitation doesn't allow us to use unique temperature sensor ID for
+each CPU core (4 CPU * 12 cores = 48 sensors).
+
+OCC uses temperature sensor ID as channel label, these labels are handled
+by phosphor-hwmon service to identify the core:
+
+     I2C               sysfs                   config.yaml
+OCC -----> BMC Kernel -------> Phosphor-hwmon -------------> DBus
+     ID                label                   label->core
+
+This patch makes OCC use own ID as channel label instead of using IPMI
+temperature sensor ID. The new identifier consists of constant prefix
+(0x0f) and core index:
+ID = 0x0f00 + INDEX(core)
+
+Signed-off-by: Artem Senichev <a.senichev@yadro.com>
+---
+ src/occ/cmdh/cmdh_fsp_cmds.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/occ/cmdh/cmdh_fsp_cmds.c b/src/occ/cmdh/cmdh_fsp_cmds.c
+index 6276992..69c646e 100755
+--- a/src/occ/cmdh/cmdh_fsp_cmds.c
++++ b/src/occ/cmdh/cmdh_fsp_cmds.c
+@@ -393,7 +393,8 @@ ERRL_RC cmdh_poll_v10(cmdh_fsp_rsp_t * o_rsp_ptr)
+     {
+         if(CORE_PRESENT(k))
+         {
+-            l_tempSensorList[l_sensorHeader.count].id = G_amec_sensor_list[TEMP2MSP0C0 + k]->ipmi_sid;
++            // Set the core label as a constant prefix with index
++            l_tempSensorList[l_sensorHeader.count].id = 0x0f00 + k;
+             l_tempSensorList[l_sensorHeader.count].value = G_amec_sensor_list[TEMP2MSP0C0 + k]->sample;
+             l_sensorHeader.count++;
+         }
+-- 
+2.19.2
+


### PR DESCRIPTION
IPMI protocol imposes limits on numbers of sensors identifiers (1 byte).
This limitation doesn't allow us to use unique temperature sensor ID for
each CPU core (4 CPU * 12 cores = 48 sensors).
Added patch makes OCC use own ID as channel label instead of using IPMI
temperature sensor ID.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>