### PR TITLE
op-build update for master-p8 with fix for Vesnin patch

### DIFF
--- a/openpower/package/hostboot-p8/hostboot-p8.mk
+++ b/openpower/package/hostboot-p8/hostboot-p8.mk
@@ -3,7 +3,7 @@
 # hostboot for POWER8
 #
 ################################################################################
-HOSTBOOT_P8_VERSION ?= e9b07d61750eb47fd57e89472a68dc0ab8dfc01b
+HOSTBOOT_P8_VERSION ?= c2471ac74bf8b39a2b2ae324b9d069baf444df2f
 
 HOSTBOOT_P8_SITE ?= $(call github,open-power,hostboot,$(HOSTBOOT_P8_VERSION))
 

--- a/openpower/patches/vesnin-patches/hostboot-p8/hostboot-0005-Fill-empty-sensor-id-to-reserved-id-0xFF.patch
+++ b/openpower/patches/vesnin-patches/hostboot-p8/hostboot-0005-Fill-empty-sensor-id-to-reserved-id-0xFF.patch
@@ -1,8 +1,9 @@
-From a1f98d850d356001d37242ccf13f94114bd6378c Mon Sep 17 00:00:00 2001
-From: Artem Senichev <a.senichev@yadro.com>
-Date: Tue, 13 Mar 2018 15:44:05 +0300
-Subject: [PATCH] Fill empty sensor id to reserved id 0xFF
+From f03937aa32b79e8bde0fa5ff09a0e11e4750bb6f Mon Sep 17 00:00:00 2001
+From: Corey Swenson <cswenson@us.ibm.com>
+Date: Mon, 14 Jan 2019 12:46:22 -0600
+Subject: [PATCH] Vesnin patch
 
+Change-Id: I1116c92f9176d53630a9316312656c03f2a16723
 
 Hank Chang: This patch achieves the following goals:
 a. Auto set all empty sensors with reserved ID - 0xFF instead of being 0x0 in
@@ -20,15 +21,23 @@ Originally created by MSI (S188)
 
 Signed-off-by: Artem Senichev <a.senichev@yadro.com>
 ---
- src/usr/ipmi/ipmisensor.C              |  5 +----
- src/usr/targeting/common/processMrw.pl | 21 ++++++++++++++++++---
- 2 files changed, 19 insertions(+), 7 deletions(-)
+ src/usr/ipmiext/ipmisensor.C           |  6 ++----
+ src/usr/targeting/common/processMrw.pl | 25 ++++++++++++++++++++-----
+ 2 files changed, 22 insertions(+), 9 deletions(-)
 
-diff --git a/src/usr/ipmi/ipmisensor.C b/src/usr/ipmi/ipmisensor.C
-index 4aa1c9f4b..a5bded63a 100644
---- a/src/usr/ipmi/ipmisensor.C
-+++ b/src/usr/ipmi/ipmisensor.C
-@@ -216,14 +216,11 @@ namespace SENSOR
+diff --git a/src/usr/ipmiext/ipmisensor.C b/src/usr/ipmiext/ipmisensor.C
+index e3c6405..63a4196 100644
+--- a/src/usr/ipmiext/ipmisensor.C
++++ b/src/usr/ipmiext/ipmisensor.C
+@@ -6,6 +6,7 @@
+ /* OpenPOWER HostBoot Project                                             */
+ /*                                                                        */
+ /* Contributors Listed Below - COPYRIGHT 2014,2019                        */
++/* [+] International Business Machines Corp.                              */
+ /*                                                                        */
+ /*                                                                        */
+ /* Licensed under the Apache License, Version 2.0 (the "License");        */
+@@ -214,14 +215,11 @@ namespace SENSOR
          }
          else
          {
@@ -45,9 +54,18 @@ index 4aa1c9f4b..a5bded63a 100644
  
          return l_err;
 diff --git a/src/usr/targeting/common/processMrw.pl b/src/usr/targeting/common/processMrw.pl
-index 8bfa7bddd..45d250872 100644
+index 8bfa7bd..66783c8 100644
 --- a/src/usr/targeting/common/processMrw.pl
 +++ b/src/usr/targeting/common/processMrw.pl
+@@ -6,7 +6,7 @@
+ #
+ # OpenPOWER HostBoot Project
+ #
+-# Contributors Listed Below - COPYRIGHT 2015,2017
++# Contributors Listed Below - COPYRIGHT 2015,2019
+ # [+] International Business Machines Corp.
+ #
+ #
 @@ -239,14 +239,29 @@ sub processIpmiSensors {
                  $sensor_name=$name."_".$name_suffix;
              }
@@ -81,6 +99,15 @@ index 8bfa7bddd..45d250872 100644
              my $str=sprintf(
                  " %30s | %10s |  0x%02X  | 0x%02X |    0x%02x   |" .
                  " %4s | %4d | %4d | %10s | %s\n",
+@@ -1428,7 +1443,7 @@ Options:
+     exit(1);
+ }
+ 
+-# eliminate extra whitespace 
++# eliminate extra whitespace
+ #    Input: string to chop
+ sub nowhitespace
+ {
 -- 
-2.14.1
+1.8.2.2
 


### PR DESCRIPTION
Changes Included for package hostboot, branch master-p8:
c2471ac - Dan Crowell - 2019-01-09 - Reduce ipmi trace spam for pnor hiomap messages
6661a2d - Andrew Jeffery - 2019-01-09 - console: ast2400: Indicate SP has met configuration requirements
a47b14c - Corey Swenson - 2019-01-09 - Increase ipmi polling frequency to every 1ms
adb33e7 - Corey Swenson - 2019-01-09 - Fix lpc hard reset
26cd997 - Andrew Jeffery - 2019-01-09 - sio: Add test for availability
775f660 - Corey Swenson - 2019-01-09 - Allow larger data for TRANS_FW LPC operations
34cb7b3 - Corey Swenson - 2019-01-09 - Cleanup fixes for hiomap ipmi-pnor enabled compile
ec77327 - Nick Bofferding - 2019-01-09 - Fix shutdown race condition and task start error in IPMI SEL library
2bf43a5 - Corey Swenson - 2019-01-09 - Enable IPMI errl after targeting is initialized
31ee7d9 - Andrew Jeffery - 2019-01-09 - errl: Mark errlogMsgHandler() as detached
377c018 - Andrew Jeffery - 2019-01-09 - pnor: ipmidd: Rename class to PnorIpmiDD
5f5341b - Andrew Jeffery - 2019-01-09 - pnor: Rename the SFC-based PnorDD class to PnorSfcDD
d689081 - Andrew Jeffery - 2019-01-09 - pnor: Introduce an IPMI-based PNOR driver implementation
cb614c0 - Andrew Jeffery - 2019-01-09 - initservice: Move ipmibase module to base image
2bb5d6f - Andrew Jeffery - 2019-01-09 - ipmi: Remove IpmiRP dependency on targeting
6c7e0cf - Andrew Jeffery - 2019-01-09 - ipmi: Split into ipmibase and ipmiext modules
2479c33 - Andrew Jeffery - 2019-01-09 - ipmi: IpmiDD and IpmiRP must never free resources
2a21fee - Andrew Jeffery - 2019-01-09 - ipmi: Terminate SEL task via shutdown event
4550da6 - Andrew Jeffery - 2019-01-09 - ipmi: Break circular dependency between IpmiDD and IpmiRP
7c7ca6b - Andrew Jeffery - 2019-01-09 - ipmi: Drop unnecessary ipmiconfig dependencies
fdcdeaa - Andrew Jeffery - 2019-01-09 - ipmi: Drop unnecessary ipmibt dependency from ipmifru
95784e3 - Andrew Jeffery - 2019-01-09 - ipmi: Introduce register_for_event() interface
7671195 - Andrew Jeffery - 2019-01-09 - assert: Include file name in assert output
70202b1 - Andrew Jeffery - 2019-01-09 - assert: Print the backtrace for critical and kernel assertions
5b8b589 - Corey Swenson - 2019-01-09 - kernel: Add backtrace function
6a4bac6 - Andrew Jeffery - 2019-01-09 - ipmi: Break circular dependency between ipmimsg and ipmibt
7bd1db1 - Andrew Jeffery - 2019-01-09 - ipmi: Replace incorrect dependency on ipmibt with ipmimsg
940c20b - Maxim Polyakov - 2019-01-02 - Fixed eeprom detection in the device tree
994e324 - Mike Baiocchi - 2018-12-20 - Add Slave-Procs-Only SBE Update via FSI I2C in istep 6.9

Signed-off-by: Corey Swenson <cswenson@us.ibm.com>