### PR TITLE
2.0.y: openpower: pnor: Fix BR2_TARGET_SKIBOOT_XZ option

### DIFF
--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -78,7 +78,7 @@ config BR2_SKIBOOT_LID_NAME
             String used to define skiboot lid filename
 
 config BR2_TARGET_SKIBOOT_XZ
-        boolean "Compress the skiboot image with XZ"
+        bool "Compress the skiboot image with XZ"
         select BR2_OPENPOWER_PNOR_XZ_ENABLED
         default y
 


### PR DESCRIPTION
op-build/openpower/package/openpower-pnor/Config.in:82: syntax error
op-build/openpower/package/openpower-pnor/Config.in:81: unknown option "boolean"

Signed-off-by: Joel Stanley <joel@jms.id.au>
(cherry picked from commit 0980b48df85cc926ee0955723f034c17efcec602)
Reported-by: Michael Lim <youhour@us.ibm.com>
Signed-off-by: Stewart Smith <stewart@linux.ibm.com>