### PR TITLE
petitboot: Reset sudo timeout & update prompt

### DIFF
--- a/openpower/package/petitboot/shell_config
+++ b/openpower/package/petitboot/shell_config
@@ -10,6 +10,10 @@ if [[ "$(id -u)" != "0" ]]; then
 	if [[ $? = 0 ]]; then
 		echo "No password set, elevating shell"
 		sudo -i
+		sudo -K
 		exit
 	fi
+	export PS1='$ '
+else
+	export PS1='# '
 fi


### PR DESCRIPTION
Call 'sudo -K' on shell exit to remove cached credentials. This avoids
the case where a user could still automatically sudo after setting a
password if they had entered the shell recently.
Also explicitly set the PS1 based on the current UID so that 'su' by
default still updates the prompt.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>