### PR TITLE
petitboot: Update login prompt message

### DIFF
--- a/openpower/package/petitboot/shell_config
+++ b/openpower/package/petitboot/shell_config
@@ -8,7 +8,7 @@ echo "You may run 'pb-sos' to gather diagnostic data"
 if [[ "$(id -u)" != "0" ]]; then
 	echo "" | sudo -S /bin/true 2&>1 >> /dev/null
 	if [[ $? = 0 ]]; then
-		echo "No password set, elevating shell"
+		echo "No password set, running as root. You may set a password in the System Configuration screen."
 		sudo -i
 		sudo -K
 		exit


### PR DESCRIPTION
If no password is set Petitboot will automatically open a shell as the
root user, and prints a message. Update this message to be more helpful
to a user if they're not aware that password authentication is
available.

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>