### PR TITLE
palmetto config: Use PNORDD_IS_IPMI

### DIFF
--- a/openpower/configs/hostboot/palmetto.config
+++ b/openpower/configs/hostboot/palmetto.config
@@ -1,9 +1,14 @@
-# The Serial Flash Controller is the AST2400 BMC.
-set   SFC_IS_AST2400
-set   BMC_DOES_SFC_INIT
+# Use IPMIDD for PNOR
+unset SFC_IS_AST2400
+set PNORDD_IS_IPMI
+unset PNORDD_IS_SFC
+unset BMC_DOES_SFC_INIT
 unset SFC_IS_IBM_DPSS
 set   ALLOW_MICRON_PNOR
 set   ALLOW_MACRONIX_PNOR
+
+#PNOR flags
+unset PNOR_TWO_SIDE_SUPPORT
 
 # VPD options.
 set MVPD_READ_FROM_HW


### PR DESCRIPTION
Fix palmetto hostboot config to use PNORDD_IS_IPMI, with other config
changes to make Palmetto hostboot correctly use IPMI for hiomap.

This needs to be run with an OpenBMC configured to use hiomap.

Signed-off-by: Lei YU <mine260309@gmail.com>