### PR TITLE
buildroot: 2019.02.1, Linux 5.0, LVM, make, localedef fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ a handful of other packages (see below).
 
 ### Dependencies for *64-bit* Ubuntu/Debian systems
 
-1. Install Ubuntu (>= 18.04) or Debian (>= 7.5) 64-bit.
+1. Install Ubuntu (>= 18.04) or Debian (>= 9) 64-bit.
 2. Enable Universe (Ubuntu only):
 
         sudo apt-get install software-properties-common
@@ -63,7 +63,7 @@ a handful of other packages (see below).
 
 ### Dependencies for *64-bit* Fedora systems
 
-1. Install Fedora 25 64-bit (older Fedora should also work).
+1. Install Fedora (>= 25) 64-bit.
 2. Install the packages necessary for the build:
 
         sudo dnf install gcc-c++ flex bison git ctags cscope expat-devel patch \

--- a/ci/Dockerfile/fedora29
+++ b/ci/Dockerfile/fedora29
@@ -1,7 +1,7 @@
 FROM fedora:29
 RUN dnf -y remove vim-minimal
 RUN dnf -y install gcc-c++ flex bison git ctags cscope expat-devel patch zlib-devel zlib-static texinfo perl-bignum "perl(XML::Simple)" "perl(YAML)" "perl(XML::SAX)" "perl(Fatal)" "perl(Thread::Queue)" "perl(Env)" "perl(XML::LibXML)" "perl(Digest::SHA1)" libxml2-devel libxslt "perl(ExtUtils::MakeMaker)"
-RUN dnf -y install which wget unzip tar cpio python bzip2 bc vim redhat-lsb-core
+RUN dnf -y install which wget unzip tar cpio python bzip2 bc vim redhat-lsb-core gawk
 RUN dnf -y install findutils
 RUN dnf -y install ncurses-devel openssl-devel
 RUN dnf -y install rsync

--- a/ci/Dockerfile/ubuntu1804
+++ b/ci/Dockerfile/ubuntu1804
@@ -4,7 +4,7 @@ RUN sed -e 's/main$/main universe/' --in-place=orig /etc/apt/sources.list
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yy cscope ctags \
   libz-dev libexpat-dev \
   python language-pack-en texinfo \
-  build-essential g++ git bison flex unzip \
+  build-essential g++ git bison flex unzip gawk \
   cpio vim-common lsb-release \
   libxml-simple-perl libxml-sax-perl libxml2-dev libxml2-utils xsltproc \
   wget bc libssl-dev python-matplotlib python-numpy graphviz eatmydata bsdmainutils rsync


### PR DESCRIPTION
Update buildroot for Linux 5.0 support, LVM bug fix, localedef fix that should re-enable translations for Petitboot. Also includes 2019.02.1 security and bugfix point release.
