### PR TITLE
ci: Add rsync to fedora docker image

### DIFF
--- a/ci/Dockerfile/fedora29
+++ b/ci/Dockerfile/fedora29
@@ -4,3 +4,4 @@ RUN dnf -y install gcc-c++ flex bison git ctags cscope expat-devel patch zlib-de
 RUN dnf -y install which wget unzip tar cpio python bzip2 bc vim redhat-lsb-core
 RUN dnf -y install findutils
 RUN dnf -y install ncurses-devel openssl-devel
+RUN dnf -y install rsync


### PR DESCRIPTION
Rsync is needed for buildroot.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>