### PR TITLE
ci: Rename defconfig in build.sh

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -45,7 +45,7 @@ while getopts ":ab:hp:c:rs:S" opt; do
       echo ""
       echo "Example:DOCKER_PREFIX=sudo ./ci/build.sh -a"
       echo -e "\tDOCKER_PREFIX=sudo ./ci/build.sh -p firestone"
-      echo -e "\tDOCKER_PREFIX=sudo ./ci/build.sh -p garrison,palmetto,openpower_p9_mambo"
+      echo -e "\tDOCKER_PREFIX=sudo ./ci/build.sh -p garrison,palmetto,opal"
       exit 1
       ;;
     r)


### PR DESCRIPTION
openpower_p9_mambo_defconfig is now called opal_defconfig.

Signed-off-by: Joel Stanley <joel@jms.id.au>