### PR TITLE
Add op-build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ To build an image for a Palmetto system:
 ```
 git clone --recursive git@github.com:open-power/op-build.git
 cd op-build
-. op-build-env
-op-build palmetto_defconfig && op-build
+./op-build palmetto_defconfig && ./op-build
 ```
 
 There are also default configurations for other platforms in

--- a/op-build
+++ b/op-build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+script_base="$(realpath $(dirname $0))"
+cd $script_base
+
+. op-build-env
+
+op-build $@


### PR DESCRIPTION
The current build instructions rely on sourcing op-build-env into the
user's shell. But that assumes the user's shell is bash or sh. There's
also no reason to pollute the user's shell with op-build related
environment variables etc.

So add an op-build script, which performs the same function and
doesn't depend on what the user's shell is and is self contained. It
just uses op-build-env, which is unchanged, so should have no impact
on CI or other existing workflows.

Update the build instructions to refer to it.

Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>