### PR TITLE
petitboot: openpower rules for usb devices

### DIFF
--- a/openpower/package/petitboot/Config.in
+++ b/openpower/package/petitboot/Config.in
@@ -32,3 +32,11 @@ config BR2_PACKAGE_PETITBOOT_MTD
 	  Adds Petitboot support for MTD devices
 
 comment "Add support for accessing MTD devices"
+
+config BR2_PACKAGE_PETITBOOT_RESTRICT_USB
+        bool "petitboot-restrict-usb"
+        depends on BR2_PACKAGE_PETITBOOT
+        help
+          Adds Petitboot UDEV rule disabling USB devices
+
+comment "Disables Petitboot USB devices"

--- a/openpower/package/petitboot/openpower.rules
+++ b/openpower/package/petitboot/openpower.rules
@@ -1,0 +1,6 @@
+# Rule to disable USB devices from being authorized
+# we want to leverage ancestry so use ATTRS first
+# query to see if the petitboot,usb-override=1 exists (grep -c == 1)
+# RESULT holds the shell command output, not the shell exit code
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{authorized_default}=="*", PROGRAM="/bin/sh -c '/usr/sbin/nvram --print-config | /bin/grep -c petitboot,usb-override=1 || true'", RESULT=="0", ATTR{authorized_default}="0"
+~

--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -50,6 +50,9 @@ define PETITBOOT_POST_INSTALL
 		$(TARGET_DIR)/usr/sbin/
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_OP_BUILD_PATH)/package/petitboot/petitboot-console-ui.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/
+        $(if $(BR2_PACKAGE_PETITBOOT_RESTRICT_USB), \
+		$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_OP_BUILD_PATH)/package/petitboot/openpower.rules \
+			$(TARGET_DIR)/etc/udev/rules.d/)
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_OP_BUILD_PATH)/package/petitboot/removable-event-poll.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_OP_BUILD_PATH)/package/petitboot/63-md-raid-arrays.rules \


### PR DESCRIPTION
USB Device Objectives:
Disable USB devices to preserve secure booting, protecting the security
vulnerability surface for openpower machines.

The Petitboot environment is limited in scope of utilities available for
instrumentation of a solution (due to space constraints in flash image).

Implement udev rule which disables the authorization of USB devices.

To build with this set BR2_PETITBOOT_RESTRICT_USB=y in defconfig.

Provide the ability for authorized access to enable USB devices
if so desired.

Implementation:
Udev rule which sets the authorized_default attribute of USB devices
to not allow USB devices to be able to connect to the kernel.

Operational Characteristics:
Upon boot no USB devices will be authorized to become functional by
the disablement of the USB device.

Once booted, if desired, an authorized user (one being able to su as root)
can perform actions which will either temporarily or persistently
enable USB devices.

Method 1 - Set petitboot,usb-override=1
Setting the petitboot,usb-override=1 will persist the desired override
and will enable USB devices from boot to boot (setting requires
root privileges).

Method 2 - Set file system authorized_default to either enable or
disable the device as desired.
(echo 1 > /sys/bus/usb/devices/usb1/authorized_default).

Special Considerations:
If access to the openpower machine is desired to allow physically attached
USB devices (such as keyboard/mouse), authorized users can access the
BMC's SOL Console and set one of the two methods described earlier for
manual overrides.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>