### PR TITLE
Update hostboot-binaries makefile

### DIFF
--- a/openpower/package/hostboot-binaries/hostboot_binaries.mk
+++ b/openpower/package/hostboot-binaries/hostboot_binaries.mk
@@ -14,28 +14,46 @@ HOSTBOOT_BINARIES_LICENSE_FILES = LICENSE
 HOSTBOOT_BINARIES_INSTALL_IMAGES = YES
 HOSTBOOT_BINARIES_INSTALL_TARGET = NO
 
+# Creating Install Commands specific to P8 and P9
+# -- P8 does not need the nimbus and axone ring files
+# -- P9 does not need the SBE files ('sbe' package is used in P9)
+# -- P9 uses the 'hcode' package to build the BR2_HOSTBOOT_BINARY_WINK_FILENAME
+
+###################################
+# P8:
+ifeq ($(BR2_OPENPOWER_POWER8),y)
+define HOSTBOOT_BINARIES_INSTALL_IMAGES_CMDS
+     $(INSTALL) -D $(@D)/cvpd.bin  $(STAGING_DIR)/hostboot_binaries/cvpd.bin
+     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_WINK_FILENAME) $(STAGING_DIR)/hostboot_binaries/
+     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_IONV_FILENAME)  $(STAGING_DIR)/hostboot_binaries/
+     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) $(STAGING_DIR)/hostboot_binaries/
+     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_SBE_FILENAME)  $(STAGING_DIR)/hostboot_binaries/
+     $(INSTALL) -D $(@D)/gpu_gpe1.bin  $(STAGING_DIR)/hostboot_binaries/gpu_gpe1.bin
+endef
+endif
+
+###################################
+# P9:
+ifeq ($(BR2_OPENPOWER_POWER9),y)
+
 NIMBUS_RING_FILE=p9n.hw.rings.bin
 NIMBUS_RING_OVERLAYS_FILE=p9n.hw.overlays.bin
 
 AXONE_RING_FILE=p9a.hw.rings.bin
 AXONE_RING_OVERLAYS_FILE=p9a.hw.overlays.bin
 
-#for P9 the hw_ref image is changing to not be padded with ECC.  However
-#all the other op-build files use the end name result.  Thus replace ".hdr.bin.ecc"
-#with ".bin"
-BIN_FILENAME ?= $(if $(BR2_OPENPOWER_POWER9),$(subst hdr.bin.ecc,bin,$(BR2_HOSTBOOT_BINARY_WINK_FILENAME)),$(BR2_HOSTBOOT_BINARY_WINK_FILENAME))
 
 define HOSTBOOT_BINARIES_INSTALL_IMAGES_CMDS
      $(INSTALL) -D $(@D)/cvpd.bin  $(STAGING_DIR)/hostboot_binaries/cvpd.bin
-     $(INSTALL) -D $(@D)/$(BIN_FILENAME) $(STAGING_DIR)/hostboot_binaries/
-     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) $(STAGING_DIR)/hostboot_binaries/
-     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_SBE_FILENAME)  $(STAGING_DIR)/hostboot_binaries/
      $(INSTALL) -D $(@D)/gpu_gpe1.bin  $(STAGING_DIR)/hostboot_binaries/gpu_gpe1.bin
+     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_IONV_FILENAME)  $(STAGING_DIR)/hostboot_binaries/
+     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) $(STAGING_DIR)/hostboot_binaries/
      $(INSTALL) -D $(@D)/$(NIMBUS_RING_FILE)  $(STAGING_DIR)/hostboot_binaries/
      $(INSTALL) -D $(@D)/$(NIMBUS_RING_OVERLAYS_FILE)  $(STAGING_DIR)/hostboot_binaries/
-     $(INSTALL) -D $(@D)/$(BR2_HOSTBOOT_BINARY_IONV_FILENAME)  $(STAGING_DIR)/hostboot_binaries/
      $(INSTALL) -D $(@D)/$(AXONE_RING_FILE)  $(STAGING_DIR)/hostboot_binaries/
      $(INSTALL) -D $(@D)/$(AXONE_RING_OVERLAYS_FILE)  $(STAGING_DIR)/hostboot_binaries/
 endef
+endif
+
 
 $(eval $(generic-package))


### PR DESCRIPTION
This commit updates the hostboot-binaries makefile to create
separate P8 or P9 install commands based on the configuration it is
building.  This eliminates installing files that are not needed
for certain configurations.

Signed-off-by: Mike Baiocchi <mbaiocch@us.ibm.com>