### PR TITLE
skiboot: Fix building device tree with host-dtc

### DIFF
--- a/openpower/package/skiboot/skiboot.mk
+++ b/openpower/package/skiboot/skiboot.mk
@@ -43,7 +43,7 @@ define SKIBOOT_BUILD_CMDS
 		$(MAKE) $(SKIBOOT_MAKE_OPTS) -C $(@D) all
 
 	$(if $(BR2_SKIBOOT_DEVICETREE), \
-		$(MAKE) -C $(@D)/external/devicetree)
+		$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)/external/devicetree)
 endef
 
 define SKIBOOT_INSTALL_IMAGES_CMDS


### PR DESCRIPTION
We need to do the build with the PATH set to the host tools. Without
this change the build fails when the host lacks a dtc, as it is not in
the PATH.

Signed-off-by: Joel Stanley <joel@jms.id.au>