### PR TITLE
linux: Work around broken OCC/powersave

### DIFF
--- a/openpower/configs/linux/skiroot_defconfig
+++ b/openpower/configs/linux/skiroot_defconfig
@@ -53,7 +53,7 @@ CONFIG_NUMA=y
 CONFIG_PPC_64K_PAGES=y
 CONFIG_SCHED_SMT=y
 CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="console=tty0 console=hvc0 ipr.fast_reboot=1 quiet"
+CONFIG_CMDLINE="console=tty0 console=hvc0 ipr.fast_reboot=1 quiet powersave=off"
 # CONFIG_SECCOMP is not set
 # CONFIG_PPC_MEM_KEYS is not set
 CONFIG_NET=y


### PR DESCRIPTION
There is a bug in current Power9 firmware where Linux appars to crash
after running for some amount of time. There are no obvous symptoms in
the skiboot msglog, or dmesg, but CPUs are shown to be stuck in the
HOMER region, part of the OCC's power management code.

Vaidy said:
> This is power management issue. Hostboot using different stop-api vs us
> in OPAL may cause issues.  As such the srtop-api and HCODE image are
> backward compatible.  But what we are discovering is that hostboot
> modified HOMER before us and there is some fallout

This can be worked around by disabling stop4 and stop5 in skiboot, or in
the kernel by setting powersave=off.

This is temporary until the OCC issue is resolved.

Signed-off-by: Joel Stanley <joel@jms.id.au>