### PR TITLE
Point op-build P8 hostboot at commit to report cache-count-disabled O…

### DIFF
--- a/openpower/package/hostboot-p8/hostboot-p8.mk
+++ b/openpower/package/hostboot-p8/hostboot-p8.mk
@@ -3,7 +3,7 @@
 # hostboot for POWER8
 #
 ################################################################################
-HOSTBOOT_P8_VERSION ?= dc218d94c57b986f5620cc8651f5aae9d08536a6
+HOSTBOOT_P8_VERSION ?= c8935157f6af41cfd83e31fef9f625c2db6c7900
 
 HOSTBOOT_P8_SITE ?= $(call github,open-power,hostboot,$(HOSTBOOT_P8_VERSION))
 


### PR DESCRIPTION
Points OP build at the P8 hostboot package commit which enables reporting to the OS
that the cache-count-disabled Spectre workaround is available.

Signed-off-by: Nick Bofferding <opensource@bofferding.net>