### PR TITLE
Remove nicole config patches directory declaration

### DIFF
--- a/openpower/configs/nicole_defconfig
+++ b/openpower/configs/nicole_defconfig
@@ -1,6 +1,5 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
-BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/nicole-patches"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_6_X=y
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"


### PR DESCRIPTION
  - The definition of a Patches directory is pointing to something
    that does not currently exist so this config fails to build

Signed-off-by: Bill Hoffa <wghoffa@us.ibm.com>