### PR TITLE
Create Build Infrastructure for OCMBFW Image Delivery

### DIFF
--- a/openpower/package/Config.in
+++ b/openpower/package/Config.in
@@ -21,4 +21,4 @@ source "$BR2_EXTERNAL_OP_BUILD_PATH/package/ima-catalog/Config.in"
 source "$BR2_EXTERNAL_OP_BUILD_PATH/package/sbe/Config.in"
 source "$BR2_EXTERNAL_OP_BUILD_PATH/package/sb-signing-utils/Config.in"
 source "$BR2_EXTERNAL_OP_BUILD_PATH/package/sb-signing-framework/Config.in"
-
+source "$BR2_EXTERNAL_OP_BUILD_PATH/package/ocmb-explorer-fw/Config.in"

--- a/openpower/package/ocmb-explorer-fw/Config.in
+++ b/openpower/package/ocmb-explorer-fw/Config.in
@@ -1,0 +1,35 @@
+config BR2_PACKAGE_OCMB_EXPLORER_FW
+        bool "ocmb_explorer_fw"
+        default y if (BR2_OPENPOWER_PLATFORM)
+        help
+            Project to stage ocmb explorer fw and binary image releases
+
+if BR2_PACKAGE_OCMB_EXPLORER_FW
+
+choice
+	prompt "OCMB Explorer Binary version"
+	default BR2_OCMB_EXPLORER_FW_LATEST_VERSION
+
+config BR2_OCMB_EXPLORER_FW_LATEST_VERSION
+	bool "Use latest OCMB_EXPLORER_FW master"
+
+config BR2_OCMB_EXPLORER_FW_CUSTOM_VERSION
+	bool "Custom OCMB_EXPLORER_FW version"
+
+endchoice
+
+config BR2_OCMB_EXPLORER_FW_CUSTOM_VERSION_VALUE
+	string "Open CAPI Memory Buffer Firmware version"
+	depends on BR2_OCMB_EXPLORER_FW_CUSTOM_VERSION
+
+config BR2_OCMB_EXPLORER_FW_VERSION
+	string
+	default "v0.b" if BR2_OCMB_EXPLORER_FW_LATEST_VERSION
+	default BR2_OCMB_EXPLORER_FW_CUSTOM_VERSION_VALUE \
+		if BR2_OCMB_EXPLORER_FW_CUSTOM_VERSION
+
+config BR2_OCMB_EXPLORER_FW_URL
+        string
+        default "https://github.com/open-power/ocmb-explorer-fw"
+
+endif

--- a/openpower/package/ocmb-explorer-fw/ocmb_explorer_fw.mk
+++ b/openpower/package/ocmb-explorer-fw/ocmb_explorer_fw.mk
@@ -1,0 +1,27 @@
+################################################################################
+#
+# ocmb-explorer-fw
+#
+################################################################################
+
+
+OCMB_EXPLORER_FW_VERSION ?= $(call qstrip,$(BR2_OCMB_EXPLORER_FW_VERSION))
+OCMB_EXPLORER_FW_SOURCE ?= $(call qstrip,$(BR2_OCMBFW_FILENAME))
+OCMB_EXPLORER_FW_SITE ?= $(call qstrip,$(BR2_OCMB_EXPLORER_FW_URL))/releases/download/$(BR2_OCMB_EXPLORER_FW_VERSION)
+
+OCMB_EXPLORER_FW_LICENSE = Apache-2.0
+OCMB_EXPLORER_FW_LICENSE_FILES = LICENSE
+
+OCMB_EXPLORER_FW_INSTALL_IMAGES = YES
+OCMB_EXPLORER_FW_INSTALL_TARGET = NO
+
+# Commands to extract and install the Open Capi Memory Buffer Firmware (OCMBFW)
+define OCMB_EXPLORER_FW_INSTALL_IMAGES_CMDS
+      $(INSTALL) -D $(@D)/$(OCMB_EXPLORER_FW_SOURCE) $(BINARIES_DIR)/
+endef
+
+define OCMB_EXPLORER_FW_EXTRACT_CMDS
+      cp $(DL_DIR)/ocmb-explorer-fw/$(OCMB_EXPLORER_FW_SOURCE) $(@D)/
+endef
+
+$(eval $(generic-package))

--- a/openpower/package/openpower-pnor/Config.in
+++ b/openpower/package/openpower-pnor/Config.in
@@ -156,7 +156,7 @@ config BR2_OPENPOWER_TARGETING_ECC_FILENAME
 
 config BR2_OCMBFW_FILENAME
         string "Name of the OCMBFW Update original file"
-        default "ocmbfw.bin"
+        default "signed_app_fw.mem"
         help
             String used to define name of OCBMFW Update original file (before any processing occurs)
 

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OPENPOWER_PNOR_VERSION ?= 03469302c58f65ff57082792cdda159795f6e488
+OPENPOWER_PNOR_VERSION ?= 4fbcc5ef382f0202fa3fc6c3451a64fc39af3588
 OPENPOWER_PNOR_SITE ?= $(call github,open-power,pnor,$(OPENPOWER_PNOR_VERSION))
 
 OPENPOWER_PNOR_LICENSE = Apache-2.0
@@ -129,7 +129,9 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -payload_filename $(BR2_SKIBOOT_LID_XZ_NAME) \
             -binary_dir $(BINARIES_DIR) \
             -bootkernel_filename $(LINUX_IMAGE_NAME) \
-	    -ocmbfw_original_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/$(BR2_OCMBFW_FILENAME) \
+	    -ocmbfw_version $(BR2_OCMB_EXPLORER_FW_VERSION) \
+	    -ocmbfw_url $(BR2_OCMB_EXPLORER_FW_URL) \
+	    -ocmbfw_original_filename $(BINARIES_DIR)/$(BR2_OCMBFW_FILENAME) \
 	    -ocmbfw_binary_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/$(BR2_OCMBFW_PROCESSED_FILENAME) \
             -pnor_layout $(@D)/"$(OPENPOWER_RELEASE)"Layouts/$(BR2_OPENPOWER_PNOR_XML_LAYOUT_FILENAME) \
             $(XZ_ARG) $(KEY_TRANSITION_ARG) $(SIGN_MODE_ARG) \


### PR DESCRIPTION
  - This is temporarily pointing to: https://github.com/wghoffa/test-binary-release/releases
    as an example for how OCMBFW binary delivery could be done (Tagged binary image release)
  - This example includes all the necessary config/makefile updates
    to enable the successful binary image extraction + processing so the image is
    placed in the correct PNOR partition
  - This is currently dependent on a PNOR change
    (https://github.com/open-power/pnor/pull/122) so it won't compile without
    pulling this change in

Signed-off-by: Bill Hoffa <wghoffa@us.ibm.com>