### PR TITLE
vesnin config: Add PNOR over HIOMAP support

### DIFF
--- a/openpower/configs/hostboot/vesnin.config
+++ b/openpower/configs/hostboot/vesnin.config
@@ -1,7 +1,9 @@
-# The Serial Flash Controller is the AST2400 BMC.
-set   SFC_IS_AST2400
-set   BMC_DOES_SFC_INIT
+# Use IPMIDD for PNOR
+unset SFC_IS_AST2400
 unset SFC_IS_IBM_DPSS
+unset BMC_DOES_SFC_INIT
+unset PNORDD_IS_SFC
+set   PNORDD_IS_IPMI
 set   ALLOW_MICRON_PNOR
 set   ALLOW_MACRONIX_PNOR
 


### PR DESCRIPTION
Use IPMI/HIOMAP to work with PNOR flash.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>