### PR TITLE
package/ocmb-explorer-fw: default to n

### DIFF
--- a/openpower/package/ocmb-explorer-fw/Config.in
+++ b/openpower/package/ocmb-explorer-fw/Config.in
@@ -1,6 +1,6 @@
 config BR2_PACKAGE_OCMB_EXPLORER_FW
         bool "ocmb_explorer_fw"
-        default y if (BR2_OPENPOWER_PLATFORM)
+        default n
         help
             Project to stage ocmb explorer fw and binary image releases
 


### PR DESCRIPTION
This package isn't currently used on any upstream OpenPOWER platforms,
so default to n. Platforms can enable it through their configs instead.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>