### PR TITLE
buildroot: Update to pick up new linux-firmware

### DIFF
--- a/openpower/scripts/firmware-whitelist
+++ b/openpower/scripts/firmware-whitelist
@@ -6,7 +6,7 @@
 # slash is required.
 whitelist=(     'acenic/'
                 'bnx2/'
-                'bnx2x/bnx2x-e2-7.13.1.0.fw'
+                'bnx2x/bnx2x-e2-7.13.11.0.fw'
                 'cxgb4/t4fw-1.16.63.0.bin'
                 'cxgb4/t4fw.bin'
                 'cxgb3/'


### PR DESCRIPTION
The 5.2 kernel requires version 7.13.11.0 of the Broadcom bnx2x
firmware. This can be found in the latest linux-firmware package.

A corresponding change has been made to the firmware whitelist script so
the new version is included.

This fixes the following symptoms:

 bnx2x 0003:01:00.0: Direct firmware load for bnx2x/bnx2x-e2-7.13.11.0.fw failed with error -2

Signed-off-by: Joel Stanley <joel@jms.id.au>