### PR TITLE
libflash: skiboot v6.5-61-g66ab3cbd

### DIFF
--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBFLASH_VERSION = v6.4
+LIBFLASH_VERSION = v6.5-61-g66ab3cbd
 LIBFLASH_SITE = $(call github,open-power,skiboot,$(LIBFLASH_VERSION))
 
 LIBFLASH_INSTALL_STAGING = YES


### PR DESCRIPTION
We have merged 100+ pathes after v6.4. I didn't realize that we have
separate package for libflash and missed to update :-(

Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>

