### PR TITLE
Update ppe42 toolchain with fixes and enhancements (obsoletes PR #3162)

### DIFF
--- a/openpower/package/ppe42-binutils/ppe42-binutils.mk
+++ b/openpower/package/ppe42-binutils/ppe42-binutils.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PPE42_BINUTILS_VERSION ?= ded0eff199fa1d9bd8be5a78935e8f023a2c5fad
+PPE42_BINUTILS_VERSION ?= c615a89c5beb032cbb00bf0c3e670319b2bbd4f5
 PPE42_BINUTILS_SITE ?= $(call github,open-power,ppe42-binutils,$(PPE42_BINUTILS_VERSION))
 PPE42_BINUTILS_LICENSE = GPLv3+
 

--- a/openpower/package/ppe42-gcc/ppe42-gcc.mk
+++ b/openpower/package/ppe42-gcc/ppe42-gcc.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PPE42_GCC_VERSION ?= c13849780c80d1ed466efbeaabcc663fe48cd87d
+PPE42_GCC_VERSION ?= b4772a9fa65ea0dd812f8f305ce157bb1cb5ab4a
 PPE42_GCC_SITE ?= $(call github,open-power,ppe42-gcc,$(PPE42_GCC_VERSION))
 PPE42_GCC_LICENSE = GPLv3+
 


### PR DESCRIPTION
(obsoletes PR #3162)

Updates to ppe42-gcc:

    * Backport fix for search_line_fast on POWER/ALTIVEC (Klaus Kiwi on Oct 29)
    * PPE42X Frame pointer not set/restored (Douglas Gilbert on Aug 22)
    * PPE42X (Douglas Gilbert on Jun 15, 2018)
    * Stack enhancements (Douglas Gilbert on May 8, 2018)

Update to ppe42-binutils:

    * New PPE instructions for P10 (Douglas Gilbert on Jun 9, 2018)

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>