### PR TITLE
openpower/libflash: Use SKIBOOT_VERSION

### DIFF
--- a/openpower/package/libflash/Config.in
+++ b/openpower/package/libflash/Config.in
@@ -1,5 +1,6 @@
 config BR2_PACKAGE_LIBFLASH
 	bool "libflash"
+	depends on BR2_PACKAGE_SKIBOOT
 	help
 	  Build libflash shared library
 

--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -4,8 +4,13 @@
 #
 ################################################################################
 
-LIBFLASH_VERSION = v6.5-61-g66ab3cbd
+ifeq ($(BR2_SKIBOOT_CUSTOM_GIT),y)
+LIBFLASH_SITE = $(call qstrip,$(BR2_SKIBOOT_CUSTOM_REPO_URL))
+LIBFLASH_SITE_METHOD = git
+else
+LIBFLASH_VERSION = $(call qstrip,$(BR2_SKIBOOT_VERSION))
 LIBFLASH_SITE = $(call github,open-power,skiboot,$(LIBFLASH_VERSION))
+endif
 
 LIBFLASH_INSTALL_STAGING = YES
 LIBFLASH_INSTALL_TARGET = YES


### PR DESCRIPTION
libflash code sits inside skiboot source tree. Use SKIBOOT_VERSION
instead of having separate version.

Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>