### PR TITLE
run build in defined locale

### DIFF
--- a/op-build-env
+++ b/op-build-env
@@ -14,6 +14,8 @@ fi
 export BR2_EXTERNAL=${__PWD}/openpower
 export BR2_DL_DIR=${__PWD}/dl
 
+export LANG=en_US.UTF-8
+
 op-build () {
     make --directory=${__PWD}/buildroot O=${__PWD}/output $@
 }


### PR DESCRIPTION
There are parts of the firmware that rely on English/C locale for some generated
content, for example testfapi2.C and testfapi2_rt.C in Hostboot are created during
the build and they are created incorrectly when the build runs in cs_CZ.UTF-8 locale.

Signed-off-by: Dan Horák <dan@danny.cz>

Fixes: https://lists.ozlabs.org/pipermail/openpower-firmware/2019-December/000435.html