### PR TITLE
Petitboot fixes for search, source commands

### DIFF
--- a/openpower/package/petitboot/petitboot-02-discover-grub-Add-blscfg-command-support-to-parse-Bo.patch
+++ b/openpower/package/petitboot/petitboot-02-discover-grub-Add-blscfg-command-support-to-parse-Bo.patch
@@ -1,0 +1,686 @@
+From 331663759206bb32e0ed1e68207deb3e78d816f7 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Thu, 22 Mar 2018 09:41:23 +0100
+Subject: [PATCH 03/23] discover/grub: Add blscfg command support to parse
+ BootLoaderSpec files
+
+The BootLoaderSpec (BLS) defines a file format for boot configurations,
+so bootloaders can parse these files and create their boot menu entries
+by using the information provided by them [0].
+
+This allow to configure the boot items as drop-in files in a directory
+instead of having to parse and modify a bootloader configuration file.
+
+The GRUB 2 bootloader provides a blscfg command that parses these files
+and creates menu entries using this information. Add support for it.
+
+[0]: https://www.freedesktop.org/wiki/Specifications/BootLoaderSpec/
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
+(cherry picked from commit 91ce1a8f8863d8f740188236f138421d17292d6c)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/Makefile.am                    |   1 +
+ discover/grub2/blscfg.c                       | 241 ++++++++++++++++++
+ discover/grub2/builtins.c                     |   9 +-
+ discover/grub2/script.c                       |   2 +-
+ discover/parser.c                             |  16 ++
+ discover/parser.h                             |   8 +
+ test/parser/Makefile.am                       |   5 +
+ .../test-grub2-blscfg-default-filename.c      |  29 +++
+ test/parser/test-grub2-blscfg-default-title.c |  36 +++
+ test/parser/test-grub2-blscfg-multiple-bls.c  |  44 ++++
+ test/parser/test-grub2-blscfg-opts-config.c   |  29 +++
+ test/parser/test-grub2-blscfg-opts-grubenv.c  |  34 +++
+ test/parser/utils.c                           |  59 +++++
+ 13 files changed, 511 insertions(+), 2 deletions(-)
+ create mode 100644 discover/grub2/blscfg.c
+ create mode 100644 test/parser/test-grub2-blscfg-default-filename.c
+ create mode 100644 test/parser/test-grub2-blscfg-default-title.c
+ create mode 100644 test/parser/test-grub2-blscfg-multiple-bls.c
+ create mode 100644 test/parser/test-grub2-blscfg-opts-config.c
+ create mode 100644 test/parser/test-grub2-blscfg-opts-grubenv.c
+
+diff --git a/discover/grub2/Makefile.am b/discover/grub2/Makefile.am
+index 130ede8..b240106 100644
+--- a/discover/grub2/Makefile.am
++++ b/discover/grub2/Makefile.am
+@@ -15,6 +15,7 @@
+ noinst_PROGRAMS += discover/grub2/grub2-parser.ro
+ 
+ discover_grub2_grub2_parser_ro_SOURCES = \
++	discover/grub2/blscfg.c \
+ 	discover/grub2/builtins.c \
+ 	discover/grub2/env.c \
+ 	discover/grub2/grub2.h \
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+new file mode 100644
+index 0000000..0f69f7e
+--- /dev/null
++++ b/discover/grub2/blscfg.c
+@@ -0,0 +1,241 @@
++
++#define _GNU_SOURCE
++
++#include <assert.h>
++#include <stdlib.h>
++#include <string.h>
++#include <dirent.h>
++
++#include <log/log.h>
++#include <file/file.h>
++#include <talloc/talloc.h>
++#include <i18n/i18n.h>
++
++#include "grub2.h"
++#include "discover/parser-conf.h"
++#include "discover/parser.h"
++
++#define BLS_DIR "/loader/entries"
++
++struct bls_state {
++	struct discover_boot_option *opt;
++	struct grub2_script *script;
++	const char *filename;
++	const char *title;
++	const char *version;
++	const char *machine_id;
++	const char *image;
++	const char *initrd;
++	const char *dtb;
++};
++
++static void bls_process_pair(struct conf_context *conf, const char *name,
++			     char *value)
++{
++	struct bls_state *state = conf->parser_info;
++	struct discover_boot_option *opt = state->opt;
++	struct boot_option *option = opt->option;
++	const char *boot_args;
++
++	if (streq(name, "title")) {
++		state->title = talloc_strdup(state, value);
++		return;
++	}
++
++	if (streq(name, "version")) {
++		state->version = talloc_strdup(state, value);
++		return;
++	}
++
++	if (streq(name, "machine-id")) {
++		state->machine_id = talloc_strdup(state, value);
++		return;
++	}
++
++	if (streq(name, "linux")) {
++		state->image = talloc_strdup(state, value);
++		return;
++	}
++
++	if (streq(name, "initrd")) {
++		state->initrd = talloc_strdup(state, value);
++		return;
++	}
++
++	if (streq(name, "devicetree")) {
++		state->dtb = talloc_strdup(state, value);
++		return;
++	}
++
++	if (streq(name, "options")) {
++		if (value[0] == '$') {
++			boot_args = script_env_get(state->script, value + 1);
++			if (!boot_args)
++				return;
++
++			option->boot_args = talloc_strdup(opt, boot_args);
++		} else {
++			option->boot_args = talloc_strdup(opt, value);
++		}
++		return;
++	}
++}
++
++static bool option_is_default(struct grub2_script *script,
++			      struct boot_option *option)
++{
++	const char *var;
++
++	var = script_env_get(script, "default");
++	if (!var)
++		return false;
++
++	if (!strcmp(var, option->id))
++		return true;
++
++	return !strcmp(var, option->name);
++}
++
++static void bls_finish(struct conf_context *conf)
++{
++	struct bls_state *state = conf->parser_info;
++	struct discover_context *dc = conf->dc;
++	struct discover_boot_option *opt = state->opt;
++	struct boot_option *option = opt->option;
++	const char *root;
++	char *filename;
++
++	if (!state->image) {
++		device_handler_status_dev_info(dc->handler, dc->device,
++					       _("linux field not found in %s"),
++					       state->filename);
++		return;
++	}
++
++	filename = basename(state->filename);
++	filename[strlen(filename) - strlen(".conf")] = '\0';
++
++	option->id = talloc_strdup(option, filename);
++
++	if (state->title)
++		option->name = talloc_strdup(option, state->title);
++	else if (state->machine_id && state->version)
++		option->name = talloc_asprintf(option, "%s %s",
++					       state->machine_id,
++					       state->version);
++	else if (state->version)
++		option->name = talloc_strdup(option, state->version);
++	else
++		option->name = talloc_strdup(option, state->image);
++
++	root = script_env_get(state->script, "root");
++
++	opt->boot_image = create_grub2_resource(opt, conf->dc->device,
++						root, state->image);
++
++	if (state->initrd)
++		opt->initrd = create_grub2_resource(opt, conf->dc->device,
++						    root, state->initrd);
++
++	if (state->dtb)
++		opt->dtb = create_grub2_resource(opt, conf->dc->device,
++						 root, state->dtb);
++
++	option->is_default = option_is_default(state->script, option);
++
++	discover_context_add_boot_option(dc, opt);
++
++	device_handler_status_dev_info(dc->handler, dc->device,
++				       _("Created menu entry from BLS file %s"),
++				       state->filename);
++}
++
++static int bls_filter(const struct dirent *ent)
++{
++	int offset = strlen(ent->d_name) - strlen(".conf");
++
++	if (offset < 0)
++		return 0;
++
++	return strncmp(ent->d_name + offset, ".conf", strlen(".conf")) == 0;
++}
++
++static int bls_sort(const struct dirent **ent_a, const struct dirent **ent_b)
++{
++	return strverscmp((*ent_b)->d_name, (*ent_a)->d_name);
++}
++
++int builtin_blscfg(struct grub2_script *script,
++		void *data __attribute__((unused)),
++		int argc __attribute__((unused)),
++		char *argv[] __attribute__((unused)));
++
++int builtin_blscfg(struct grub2_script *script,
++		void *data __attribute__((unused)),
++		int argc __attribute__((unused)),
++		char *argv[] __attribute__((unused)))
++{
++	struct discover_context *dc = script->ctx;
++	struct dirent **bls_entries;
++	struct conf_context *conf;
++	struct bls_state *state;
++	char *buf, *filename;
++	int n, len, rc = -1;
++
++	conf = talloc_zero(dc, struct conf_context);
++	if (!conf)
++		return rc;
++
++	conf->dc = dc;
++	conf->get_pair = conf_get_pair_space;
++	conf->process_pair = bls_process_pair;
++	conf->finish = bls_finish;
++
++	n = parser_scandir(dc, BLS_DIR, &bls_entries, bls_filter, bls_sort);
++	if (n <= 0)
++		goto err;
++
++	while (n--) {
++		filename = talloc_asprintf(dc, BLS_DIR"/%s",
++					   bls_entries[n]->d_name);
++		if (!filename)
++			break;
++
++		state = talloc_zero(conf, struct bls_state);
++		if (!state)
++			break;
++
++		state->opt = discover_boot_option_create(dc, dc->device);
++		if (!state->opt)
++			break;
++
++		state->script = script;
++		state->filename = filename;
++		conf->parser_info = state;
++
++		rc = parser_request_file(dc, dc->device, filename, &buf, &len);
++		if (rc)
++			break;
++
++		conf_parse_buf(conf, buf, len);
++
++		talloc_free(buf);
++		talloc_free(state);
++		talloc_free(filename);
++		free(bls_entries[n]);
++	}
++
++	if (n > 0) {
++		device_handler_status_dev_info(dc->handler, dc->device,
++					       _("Scanning %s failed"),
++					       BLS_DIR);
++		do {
++			free(bls_entries[n]);
++		} while (n-- > 0);
++	}
++
++	free(bls_entries);
++err:
++	talloc_free(conf);
++	return rc;
++}
+diff --git a/discover/grub2/builtins.c b/discover/grub2/builtins.c
+index c16b639..e42821a 100644
+--- a/discover/grub2/builtins.c
++++ b/discover/grub2/builtins.c
+@@ -330,7 +330,10 @@ extern int builtin_load_env(struct grub2_script *script,
+ int builtin_save_env(struct grub2_script *script,
+ 		void *data __attribute__((unused)),
+ 		int argc, char *argv[]);
+-
++int builtin_blscfg(struct grub2_script *script,
++		void *data __attribute__((unused)),
++		int argc __attribute__((unused)),
++		char *argv[] __attribute__((unused)));
+ 
+ static struct {
+ 	const char *name;
+@@ -380,6 +383,10 @@ static struct {
+ 		.name = "save_env",
+ 		.fn = builtin_save_env,
+ 	},
++	{
++		.name = "blscfg",
++		.fn = builtin_blscfg,
++	}
+ };
+ 
+ static const char *nops[] = {
+diff --git a/discover/grub2/script.c b/discover/grub2/script.c
+index ed81a20..1a802b9 100644
+--- a/discover/grub2/script.c
++++ b/discover/grub2/script.c
+@@ -103,7 +103,7 @@ static bool is_delim(char c)
+ }
+ 
+ static bool option_is_default(struct grub2_script *script,
+-		struct discover_boot_option *opt, const char *id)
++			      struct discover_boot_option *opt, const char *id)
+ {
+ 	unsigned int default_idx;
+ 	const char *var;
+diff --git a/discover/parser.c b/discover/parser.c
+index 5598f96..9fe1925 100644
+--- a/discover/parser.c
++++ b/discover/parser.c
+@@ -128,6 +128,22 @@ out:
+ 	return -1;
+ }
+ 
++int parser_scandir(struct discover_context *ctx, const char *dirname,
++		   struct dirent ***files, int (*filter)(const struct dirent *),
++		   int (*comp)(const struct dirent **, const struct dirent **))
++{
++	char *path;
++	int n;
++
++	path = talloc_asprintf(ctx, "%s%s", ctx->device->mount_path, dirname);
++	if (!path)
++		return -1;
++
++	n = scandir(path, files, filter, comp);
++	talloc_free(path);
++	return n;
++}
++
+ void iterate_parsers(struct discover_context *ctx)
+ {
+ 	struct p_item* i;
+diff --git a/discover/parser.h b/discover/parser.h
+index fc165c5..bff52e3 100644
+--- a/discover/parser.h
++++ b/discover/parser.h
+@@ -5,6 +5,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
++#include <dirent.h>
+ 
+ #include "device-handler.h"
+ 
+@@ -76,5 +77,12 @@ int parser_request_url(struct discover_context *ctx, struct pb_url *url,
+ int parser_stat_path(struct discover_context *ctx,
+ 		struct discover_device *dev, const char *path,
+ 		struct stat *statbuf);
++/* Function used to list the files on a directory. The dirname should
++ * be relative to the discover context device mount path. It returns
++ * the number of files returned in files or a negative value on error.
++ */
++int parser_scandir(struct discover_context *ctx, const char *dirname,
++		   struct dirent ***files, int (*filter)(const struct dirent *),
++		   int (*comp)(const struct dirent **, const struct dirent **));
+ 
+ #endif /* _PARSER_H */
+diff --git a/test/parser/Makefile.am b/test/parser/Makefile.am
+index 8c01ec8..15be09d 100644
+--- a/test/parser/Makefile.am
++++ b/test/parser/Makefile.am
+@@ -40,6 +40,11 @@ parser_TESTS = \
+ 	test/parser/test-grub2-parser-error \
+ 	test/parser/test-grub2-test-file-ops \
+ 	test/parser/test-grub2-single-yocto \
++	test/parser/test-grub2-blscfg-default-filename \
++	test/parser/test-grub2-blscfg-default-title \
++	test/parser/test-grub2-blscfg-multiple-bls \
++	test/parser/test-grub2-blscfg-opts-config \
++	test/parser/test-grub2-blscfg-opts-grubenv \
+ 	test/parser/test-kboot-single \
+ 	test/parser/test-yaboot-empty \
+ 	test/parser/test-yaboot-single \
+diff --git a/test/parser/test-grub2-blscfg-default-filename.c b/test/parser/test-grub2-blscfg-default-filename.c
+new file mode 100644
+index 0000000..fb74059
+--- /dev/null
++++ b/test/parser/test-grub2-blscfg-default-filename.c
+@@ -0,0 +1,29 @@
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++set default=6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64
++blscfg
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
++			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
++			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
++			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
++
++	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	ctx = test->ctx;
++
++	opt = get_boot_option(ctx, 0);
++
++	check_is_default(opt);
++}
+diff --git a/test/parser/test-grub2-blscfg-default-title.c b/test/parser/test-grub2-blscfg-default-title.c
+new file mode 100644
+index 0000000..94acf80
+--- /dev/null
++++ b/test/parser/test-grub2-blscfg-default-title.c
+@@ -0,0 +1,36 @@
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++load_env
++set default=${saved_entry}
++blscfg
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	test_add_file_string(test, test->ctx->device,
++			     "/boot/grub2/grubenv",
++			     "# GRUB Environment Block\n"
++			     "saved_entry=Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "kernelopts=root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
++			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
++			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
++			     "options $kernelopts\n");
++
++	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	ctx = test->ctx;
++
++	opt = get_boot_option(ctx, 0);
++
++	check_is_default(opt);
++}
+diff --git a/test/parser/test-grub2-blscfg-multiple-bls.c b/test/parser/test-grub2-blscfg-multiple-bls.c
+new file mode 100644
+index 0000000..8fd218c
+--- /dev/null
++++ b/test/parser/test-grub2-blscfg-multiple-bls.c
+@@ -0,0 +1,44 @@
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++blscfg
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
++			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
++			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
++			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n\n");
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.14.18-300.fc28.x86_64.conf",
++			     "title Fedora (4.14.18-300.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.14.18-300.fc28.x86_64\n"
++			     "initrd /initramfs-4.14.18-300.fc28.x86_64.img\n"
++			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
++
++	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	ctx = test->ctx;
++
++	check_boot_option_count(ctx, 2);
++	opt = get_boot_option(ctx, 0);
++
++	check_name(opt, "Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)");
++	check_resolved_local_resource(opt->boot_image, ctx->device,
++			"/vmlinuz-4.15.2-302.fc28.x86_64");
++
++	opt = get_boot_option(ctx, 1);
++
++	check_name(opt, "Fedora (4.14.18-300.fc28.x86_64) 28 (Twenty Eight)");
++	check_resolved_local_resource(opt->initrd, ctx->device,
++			"/initramfs-4.14.18-300.fc28.x86_64.img");
++}
+diff --git a/test/parser/test-grub2-blscfg-opts-config.c b/test/parser/test-grub2-blscfg-opts-config.c
+new file mode 100644
+index 0000000..856aae2
+--- /dev/null
++++ b/test/parser/test-grub2-blscfg-opts-config.c
+@@ -0,0 +1,29 @@
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++set kernelopts=root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root
++blscfg
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
++			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
++			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
++			     "options $kernelopts\n");
++
++	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	ctx = test->ctx;
++
++	opt = get_boot_option(ctx, 0);
++
++	check_args(opt, "root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root");
++}
+diff --git a/test/parser/test-grub2-blscfg-opts-grubenv.c b/test/parser/test-grub2-blscfg-opts-grubenv.c
+new file mode 100644
+index 0000000..c77c589
+--- /dev/null
++++ b/test/parser/test-grub2-blscfg-opts-grubenv.c
+@@ -0,0 +1,34 @@
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++load_env
++blscfg
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	test_add_file_string(test, test->ctx->device,
++			     "/boot/grub2/grubenv",
++			     "# GRUB Environment Block\n"
++			     "kernelopts=root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
++			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
++			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
++			     "options $kernelopts\n");
++
++	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	ctx = test->ctx;
++
++	opt = get_boot_option(ctx, 0);
++
++	check_args(opt, "root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root");
++}
+diff --git a/test/parser/utils.c b/test/parser/utils.c
+index 47779c8..394efb3 100644
+--- a/test/parser/utils.c
++++ b/test/parser/utils.c
+@@ -309,6 +309,65 @@ int parser_replace_file(struct discover_context *ctx,
+ 	return 0;
+ }
+ 
++int parser_scandir(struct discover_context *ctx, const char *dirname,
++		   struct dirent ***files, int (*filter)(const struct dirent *)
++		   __attribute__((unused)),
++		   int (*comp)(const struct dirent **, const struct dirent **)
++		   __attribute__((unused)))
++{
++	struct parser_test *test = ctx->test_data;
++	struct test_file *f;
++	char *filename;
++	struct dirent **dirents = NULL, **new_dirents;
++	int n = 0, namelen;
++
++	list_for_each_entry(&test->files, f, list) {
++		if (f->dev != ctx->device)
++			continue;
++
++		filename = strrchr(f->name, '/');
++		if (!filename)
++			continue;
++
++		namelen = strlen(filename);
++
++		if (strncmp(f->name, dirname, strlen(f->name) - namelen))
++			continue;
++
++		if (!dirents) {
++			dirents = malloc(sizeof(struct dirent *));
++		} else {
++			new_dirents = realloc(dirents, sizeof(struct dirent *)
++					      * (n + 1));
++			if (!new_dirents)
++				goto err_cleanup;
++
++			dirents = new_dirents;
++		}
++
++		dirents[n] = malloc(sizeof(struct dirent) + namelen + 1);
++
++		if (!dirents[n])
++			goto err_cleanup;
++
++		strcpy(dirents[n]->d_name, filename + 1);
++		n++;
++	}
++
++	*files = dirents;
++
++	return n;
++
++err_cleanup:
++	do {
++		free(dirents[n]);
++	} while (n-- > 0);
++
++	free(dirents);
++
++	return -1;
++}
++
+ struct load_url_result *load_url_async(void *ctx, struct pb_url *url,
+ 		load_url_complete async_cb, void *async_data,
+ 		waiter_cb stdout_cb, void *stdout_data)
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-03-discover-grub-Allow-to-choose-a-different-BLS-direct.patch
+++ b/openpower/package/petitboot/petitboot-03-discover-grub-Allow-to-choose-a-different-BLS-direct.patch
@@ -1,0 +1,53 @@
+From 4de19d56545a3f592eb64ab7afc20e1c4e93ad53 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Wed, 28 Mar 2018 14:24:43 +0200
+Subject: [PATCH 04/23] discover/grub: Allow to choose a different BLS
+ directory
+
+The default path to search for BootLoaderSpec configuration files is
+/loader/entries but in some setups a different directory may be used.
+
+So allow this to be chosen by using a blsdir GRUB environment variable.
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
+(cherry picked from commit d01dfd5a6ca8283939265875dc69d665f955aba2)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/blscfg.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+index 0f69f7e..02ac621 100644
+--- a/discover/grub2/blscfg.c
++++ b/discover/grub2/blscfg.c
+@@ -180,6 +180,7 @@ int builtin_blscfg(struct grub2_script *script,
+ 	struct conf_context *conf;
+ 	struct bls_state *state;
+ 	char *buf, *filename;
++	const char *blsdir;
+ 	int n, len, rc = -1;
+ 
+ 	conf = talloc_zero(dc, struct conf_context);
+@@ -191,12 +192,16 @@ int builtin_blscfg(struct grub2_script *script,
+ 	conf->process_pair = bls_process_pair;
+ 	conf->finish = bls_finish;
+ 
+-	n = parser_scandir(dc, BLS_DIR, &bls_entries, bls_filter, bls_sort);
++	blsdir = script_env_get(script, "blsdir");
++	if (!blsdir)
++		blsdir = BLS_DIR;
++
++	n = parser_scandir(dc, blsdir, &bls_entries, bls_filter, bls_sort);
+ 	if (n <= 0)
+ 		goto err;
+ 
+ 	while (n--) {
+-		filename = talloc_asprintf(dc, BLS_DIR"/%s",
++		filename = talloc_asprintf(dc, "%s/%s", blsdir,
+ 					   bls_entries[n]->d_name);
+ 		if (!filename)
+ 			break;
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-04-discover-grub-Don-t-add-discover-context-boot-option.patch
+++ b/openpower/package/petitboot/petitboot-04-discover-grub-Don-t-add-discover-context-boot-option.patch
@@ -1,0 +1,33 @@
+From 000a914853db08b496fa25054bce1b087b24ae77 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Tue, 17 Apr 2018 19:08:59 +0200
+Subject: [PATCH 05/23] discover/grub: Don't add discover context boot options
+ in blscfg handler
+
+Instead of adding a boot option explicitly, just add it to the grub script
+boot option list and increment the number of options. That way BLS entries
+will be known by the grub script handler and can check if is a valid index.
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
+---
+ discover/grub2/blscfg.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+index 02ac621..5fde217 100644
+--- a/discover/grub2/blscfg.c
++++ b/discover/grub2/blscfg.c
+@@ -143,7 +143,8 @@ static void bls_finish(struct conf_context *conf)
+ 
+ 	option->is_default = option_is_default(state->script, option);
+ 
+-	discover_context_add_boot_option(dc, opt);
++	list_add_tail(&state->script->options, &opt->list);
++	state->script->n_options++;
+ 
+ 	device_handler_status_dev_info(dc->handler, dc->device,
+ 				       _("Created menu entry from BLS file %s"),
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-05-discover-grub-Allow-to-set-a-default-index-for-BLS-e.patch
+++ b/openpower/package/petitboot/petitboot-05-discover-grub-Allow-to-set-a-default-index-for-BLS-e.patch
@@ -1,0 +1,156 @@
+From 3ba42b328a6074b950ed33e01e3ae09c982eedbf Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Tue, 17 Apr 2018 19:09:00 +0200
+Subject: [PATCH 06/23] discover/grub: Allow to set a default index for BLS
+ entries
+
+When the BLS support was added, the conclusion was that default indexes
+didn't apply for BLS snippets. But for GRUB 2 the indexes refers to the
+boot menu entries in memory, regardless of how these were generated.
+
+Since in GRUB 2 is valid to set a default index even for menu entries
+generated from BLS fragments, allow this to also be done in Petitboot.
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
+(cherry picked from commit c41ffccdaf16b0820904c5dd2e5d7612bfbefc65)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/blscfg.c                       | 17 +++++--
+ test/parser/Makefile.am                       |  1 +
+ test/parser/test-grub2-blscfg-default-index.c | 45 +++++++++++++++++++
+ 3 files changed, 59 insertions(+), 4 deletions(-)
+ create mode 100644 test/parser/test-grub2-blscfg-default-index.c
+
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+index 5fde217..2e60f5e 100644
+--- a/discover/grub2/blscfg.c
++++ b/discover/grub2/blscfg.c
+@@ -20,6 +20,7 @@
+ struct bls_state {
+ 	struct discover_boot_option *opt;
+ 	struct grub2_script *script;
++	unsigned int idx;
+ 	const char *filename;
+ 	const char *title;
+ 	const char *version;
+@@ -81,19 +82,25 @@ static void bls_process_pair(struct conf_context *conf, const char *name,
+ 	}
+ }
+ 
+-static bool option_is_default(struct grub2_script *script,
++static bool option_is_default(struct bls_state *state,
+ 			      struct boot_option *option)
+ {
++	unsigned int idx;
+ 	const char *var;
++	char *end;
+ 
+-	var = script_env_get(script, "default");
++	var = script_env_get(state->script, "default");
+ 	if (!var)
+ 		return false;
+ 
+ 	if (!strcmp(var, option->id))
+ 		return true;
+ 
+-	return !strcmp(var, option->name);
++	if (!strcmp(var, option->name))
++		return true;
++
++	idx = strtoul(var, &end, 10);
++	return end != var && *end == '\0' && idx == state->idx;
+ }
+ 
+ static void bls_finish(struct conf_context *conf)
+@@ -141,7 +148,7 @@ static void bls_finish(struct conf_context *conf)
+ 		opt->dtb = create_grub2_resource(opt, conf->dc->device,
+ 						 root, state->dtb);
+ 
+-	option->is_default = option_is_default(state->script, option);
++	option->is_default = option_is_default(state, option);
+ 
+ 	list_add_tail(&state->script->options, &opt->list);
+ 	state->script->n_options++;
+@@ -176,6 +183,7 @@ int builtin_blscfg(struct grub2_script *script,
+ 		int argc __attribute__((unused)),
+ 		char *argv[] __attribute__((unused)))
+ {
++	unsigned int current_idx = script->n_options;
+ 	struct discover_context *dc = script->ctx;
+ 	struct dirent **bls_entries;
+ 	struct conf_context *conf;
+@@ -217,6 +225,7 @@ int builtin_blscfg(struct grub2_script *script,
+ 
+ 		state->script = script;
+ 		state->filename = filename;
++		state->idx = current_idx++;
+ 		conf->parser_info = state;
+ 
+ 		rc = parser_request_file(dc, dc->device, filename, &buf, &len);
+diff --git a/test/parser/Makefile.am b/test/parser/Makefile.am
+index 15be09d..2fc19fa 100644
+--- a/test/parser/Makefile.am
++++ b/test/parser/Makefile.am
+@@ -41,6 +41,7 @@ parser_TESTS = \
+ 	test/parser/test-grub2-test-file-ops \
+ 	test/parser/test-grub2-single-yocto \
+ 	test/parser/test-grub2-blscfg-default-filename \
++	test/parser/test-grub2-blscfg-default-index \
+ 	test/parser/test-grub2-blscfg-default-title \
+ 	test/parser/test-grub2-blscfg-multiple-bls \
+ 	test/parser/test-grub2-blscfg-opts-config \
+diff --git a/test/parser/test-grub2-blscfg-default-index.c b/test/parser/test-grub2-blscfg-default-index.c
+new file mode 100644
+index 0000000..4ef3e2e
+--- /dev/null
++++ b/test/parser/test-grub2-blscfg-default-index.c
+@@ -0,0 +1,45 @@
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++set default=2
++menuentry 'title Fedora (4.15-9-304.fc28.x86_64) 28 (Twenty Eight)' {
++	linux   /vmlinuz-4.15-9-301.fc28.x86_64
++}
++
++menuentry 'title Fedora (4.15.6-300.fc28.x86_64) 28 (Twenty Eight)' {
++	linux   /vmlinuz-4.15.6-300.fc28.x86_64
++}
++blscfg
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-300.fc28.x86_64.conf",
++			     "title Fedora (4.15.2-300.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.15.2-300.fc28.x86_64\n"
++			     "initrd /initramfs-4.15.2-300.fc28.x86_64.img\n"
++			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n\n");
++
++	test_add_file_string(test, test->ctx->device,
++			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.14.18-300.fc28.x86_64.conf",
++			     "title Fedora (4.14.18-300.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "linux /vmlinuz-4.14.18-300.fc28.x86_64\n"
++			     "initrd /initramfs-4.14.18-300.fc28.x86_64.img\n"
++			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
++
++	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	ctx = test->ctx;
++
++	opt = get_boot_option(ctx, 2);
++
++	check_name(opt, "Fedora (4.15.2-300.fc28.x86_64) 28 (Twenty Eight)");
++
++	check_is_default(opt);
++}
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-06-discover-grub-Add-cmdline-signature-support-for-BLS-.patch
+++ b/openpower/package/petitboot/petitboot-06-discover-grub-Add-cmdline-signature-support-for-BLS-.patch
@@ -1,0 +1,36 @@
+From 4da3a17dab494958e3fb168fbeebe4b0b8a3fe30 Mon Sep 17 00:00:00 2001
+From: Brett Grandbois <brett.grandbois@opengear.com>
+Date: Thu, 3 May 2018 15:30:20 +1000
+Subject: [PATCH 07/23] discover/grub: Add cmdline signature support for BLS
+ entries
+
+Follow along the way the linux builtin does it.
+
+Signed-off-by: Brett Grandbois <brett.grandbois@opengear.com>
+Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
+(cherry picked from commit fa44993a61fc7ca0f3f73233ebf761dabfd5a1fa)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/blscfg.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+index 2e60f5e..7709324 100644
+--- a/discover/grub2/blscfg.c
++++ b/discover/grub2/blscfg.c
+@@ -148,6 +148,12 @@ static void bls_finish(struct conf_context *conf)
+ 		opt->dtb = create_grub2_resource(opt, conf->dc->device,
+ 						 root, state->dtb);
+ 
++	char* args_sigfile_default = talloc_asprintf(opt,
++		"%s.cmdline.sig", state->image);
++	opt->args_sig_file = create_grub2_resource(opt, conf->dc->device,
++						root, args_sigfile_default);
++	talloc_free(args_sigfile_default);
++
+ 	option->is_default = option_is_default(state, option);
+ 
+ 	list_add_tail(&state->script->options, &opt->list);
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-07-discover-grub-Use-different-paths-to-search-for-the-.patch
+++ b/openpower/package/petitboot/petitboot-07-discover-grub-Use-different-paths-to-search-for-the-.patch
@@ -1,0 +1,208 @@
+From af2b124573b071acfdf3cd2f50f32d708898ef17 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Tue, 12 Jun 2018 12:18:33 +0200
+Subject: [PATCH 08/23] discover/grub: Use different paths to search for the
+ BLS directory
+
+Currenlty the BLS fragments are only searched in the /loader/entries
+directory, but this assumes that there is a boot partition mounted
+in /boot. This may not always be the case, /boot may not be a mount
+point and just a directory inside the root partition.
+
+To cover this case, Petitboot tries to find a GRUB 2 config file in
+different paths. So let's do the same for the BLS files directory.
+
+Also change some of the unit tests to use /boot/loader/entries as a
+BLS directory instead of /loader/entries.
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
+(cherry picked from commit 6d06f0dbe1195cd8be7d3c54d02012ff16466d0c)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/blscfg.c                       | 22 ++++++++++++++++---
+ .../test-grub2-blscfg-default-filename.c      |  8 ++++---
+ test/parser/test-grub2-blscfg-default-index.c | 14 +++++++-----
+ test/parser/test-grub2-blscfg-default-title.c |  8 ++++---
+ test/parser/test-grub2-blscfg-multiple-bls.c  |  2 ++
+ test/parser/test-grub2-blscfg-opts-config.c   |  2 ++
+ test/parser/test-grub2-blscfg-opts-grubenv.c  |  2 ++
+ 7 files changed, 43 insertions(+), 15 deletions(-)
+
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+index 7709324..8ab016b 100644
+--- a/discover/grub2/blscfg.c
++++ b/discover/grub2/blscfg.c
+@@ -15,7 +15,11 @@
+ #include "discover/parser-conf.h"
+ #include "discover/parser.h"
+ 
+-#define BLS_DIR "/loader/entries"
++static const char *const bls_dirs[] = {
++	"/loader/entries",
++	"/boot/loader/entries",
++	NULL
++};
+ 
+ struct bls_state {
+ 	struct discover_boot_option *opt;
+@@ -195,8 +199,10 @@ int builtin_blscfg(struct grub2_script *script,
+ 	struct conf_context *conf;
+ 	struct bls_state *state;
+ 	char *buf, *filename;
++	const char * const *dir;
+ 	const char *blsdir;
+ 	int n, len, rc = -1;
++	struct stat statbuf;
+ 
+ 	conf = talloc_zero(dc, struct conf_context);
+ 	if (!conf)
+@@ -209,7 +215,17 @@ int builtin_blscfg(struct grub2_script *script,
+ 
+ 	blsdir = script_env_get(script, "blsdir");
+ 	if (!blsdir)
+-		blsdir = BLS_DIR;
++		for (dir = bls_dirs; *dir; dir++)
++			if (!parser_stat_path(dc, dc->device, *dir, &statbuf)) {
++				blsdir = *dir;
++				break;
++			}
++
++	if (!blsdir) {
++		device_handler_status_dev_info(dc->handler, dc->device,
++					       _("BLS directory wasn't found"));
++		goto err;
++	}
+ 
+ 	n = parser_scandir(dc, blsdir, &bls_entries, bls_filter, bls_sort);
+ 	if (n <= 0)
+@@ -249,7 +265,7 @@ int builtin_blscfg(struct grub2_script *script,
+ 	if (n > 0) {
+ 		device_handler_status_dev_info(dc->handler, dc->device,
+ 					       _("Scanning %s failed"),
+-					       BLS_DIR);
++					       blsdir);
+ 		do {
+ 			free(bls_entries[n]);
+ 		} while (n-- > 0);
+diff --git a/test/parser/test-grub2-blscfg-default-filename.c b/test/parser/test-grub2-blscfg-default-filename.c
+index fb74059..80a0e22 100644
+--- a/test/parser/test-grub2-blscfg-default-filename.c
++++ b/test/parser/test-grub2-blscfg-default-filename.c
+@@ -10,11 +10,13 @@ void run_test(struct parser_test *test)
+ 	struct discover_boot_option *opt;
+ 	struct discover_context *ctx;
+ 
++	test_add_dir(test, test->ctx->device, "/boot/loader/entries");
++
+ 	test_add_file_string(test, test->ctx->device,
+-			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
++			     "/boot/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
+ 			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
+-			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
+-			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
++			     "linux /boot/vmlinuz-4.15.2-302.fc28.x86_64\n"
++			     "initrd /boot/initramfs-4.15.2-302.fc28.x86_64.img\n"
+ 			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
+ 
+ 	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
+diff --git a/test/parser/test-grub2-blscfg-default-index.c b/test/parser/test-grub2-blscfg-default-index.c
+index 4ef3e2e..b792d86 100644
+--- a/test/parser/test-grub2-blscfg-default-index.c
++++ b/test/parser/test-grub2-blscfg-default-index.c
+@@ -17,18 +17,20 @@ void run_test(struct parser_test *test)
+ 	struct discover_boot_option *opt;
+ 	struct discover_context *ctx;
+ 
++	test_add_dir(test, test->ctx->device, "/boot/loader/entries");
++
+ 	test_add_file_string(test, test->ctx->device,
+-			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-300.fc28.x86_64.conf",
++			     "/boot/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-300.fc28.x86_64.conf",
+ 			     "title Fedora (4.15.2-300.fc28.x86_64) 28 (Twenty Eight)\n"
+-			     "linux /vmlinuz-4.15.2-300.fc28.x86_64\n"
+-			     "initrd /initramfs-4.15.2-300.fc28.x86_64.img\n"
++			     "linux /boot/vmlinuz-4.15.2-300.fc28.x86_64\n"
++			     "initrd /boot/initramfs-4.15.2-300.fc28.x86_64.img\n"
+ 			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n\n");
+ 
+ 	test_add_file_string(test, test->ctx->device,
+-			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.14.18-300.fc28.x86_64.conf",
++			     "/boot/loader/entries/6c063c8e48904f2684abde8eea303f41-4.14.18-300.fc28.x86_64.conf",
+ 			     "title Fedora (4.14.18-300.fc28.x86_64) 28 (Twenty Eight)\n"
+-			     "linux /vmlinuz-4.14.18-300.fc28.x86_64\n"
+-			     "initrd /initramfs-4.14.18-300.fc28.x86_64.img\n"
++			     "linux /boot/vmlinuz-4.14.18-300.fc28.x86_64\n"
++			     "initrd /boot/initramfs-4.14.18-300.fc28.x86_64.img\n"
+ 			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
+ 
+ 	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
+diff --git a/test/parser/test-grub2-blscfg-default-title.c b/test/parser/test-grub2-blscfg-default-title.c
+index 94acf80..778dcc0 100644
+--- a/test/parser/test-grub2-blscfg-default-title.c
++++ b/test/parser/test-grub2-blscfg-default-title.c
+@@ -11,6 +11,8 @@ void run_test(struct parser_test *test)
+ 	struct discover_boot_option *opt;
+ 	struct discover_context *ctx;
+ 
++	test_add_dir(test, test->ctx->device, "/boot/loader/entries");
++
+ 	test_add_file_string(test, test->ctx->device,
+ 			     "/boot/grub2/grubenv",
+ 			     "# GRUB Environment Block\n"
+@@ -18,10 +20,10 @@ void run_test(struct parser_test *test)
+ 			     "kernelopts=root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
+ 
+ 	test_add_file_string(test, test->ctx->device,
+-			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
++			     "/boot/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
+ 			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
+-			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
+-			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
++			     "linux /boot/vmlinuz-4.15.2-302.fc28.x86_64\n"
++			     "initrd /boot/initramfs-4.15.2-302.fc28.x86_64.img\n"
+ 			     "options $kernelopts\n");
+ 
+ 	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
+diff --git a/test/parser/test-grub2-blscfg-multiple-bls.c b/test/parser/test-grub2-blscfg-multiple-bls.c
+index 8fd218c..94f40d1 100644
+--- a/test/parser/test-grub2-blscfg-multiple-bls.c
++++ b/test/parser/test-grub2-blscfg-multiple-bls.c
+@@ -9,6 +9,8 @@ void run_test(struct parser_test *test)
+ 	struct discover_boot_option *opt;
+ 	struct discover_context *ctx;
+ 
++	test_add_dir(test, test->ctx->device, "/loader/entries");
++
+ 	test_add_file_string(test, test->ctx->device,
+ 			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
+ 			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
+diff --git a/test/parser/test-grub2-blscfg-opts-config.c b/test/parser/test-grub2-blscfg-opts-config.c
+index 856aae2..fdce229 100644
+--- a/test/parser/test-grub2-blscfg-opts-config.c
++++ b/test/parser/test-grub2-blscfg-opts-config.c
+@@ -10,6 +10,8 @@ void run_test(struct parser_test *test)
+ 	struct discover_boot_option *opt;
+ 	struct discover_context *ctx;
+ 
++	test_add_dir(test, test->ctx->device, "/loader/entries");
++
+ 	test_add_file_string(test, test->ctx->device,
+ 			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
+ 			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
+diff --git a/test/parser/test-grub2-blscfg-opts-grubenv.c b/test/parser/test-grub2-blscfg-opts-grubenv.c
+index c77c589..544a5de 100644
+--- a/test/parser/test-grub2-blscfg-opts-grubenv.c
++++ b/test/parser/test-grub2-blscfg-opts-grubenv.c
+@@ -10,6 +10,8 @@ void run_test(struct parser_test *test)
+ 	struct discover_boot_option *opt;
+ 	struct discover_context *ctx;
+ 
++	test_add_dir(test, test->ctx->device, "/loader/entries");
++
+ 	test_add_file_string(test, test->ctx->device,
+ 			     "/boot/grub2/grubenv",
+ 			     "# GRUB Environment Block\n"
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-08-discover-grub-Improve-BLS-grub-environment-variables.patch
+++ b/openpower/package/petitboot/petitboot-08-discover-grub-Improve-BLS-grub-environment-variables.patch
@@ -1,0 +1,224 @@
+From 4d83815de5987c67c4b0aa55b50aa1089c481b99 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Tue, 12 Jun 2018 12:18:34 +0200
+Subject: [PATCH 09/23] discover/grub: Improve BLS grub environment variables
+ expansion
+
+The fields from a BootLoaderSpec file can contain environment variables,
+in GRUB 2 these are show verbatim and are evaluated later when an entry
+is selected. But on Petitboot these have to be expanded before creating
+the GRUB 2 resources and show in the UI the values after the evaluation.
+
+The current blscfg handler had a very limited support for variables, it
+only had support for the options field and also didn't take into account
+that variables could be mixed with literal values.
+
+So for example the following fields were not expanded correctly:
+
+  linux   $bootprefix/vmlinuz
+
+  options $kernelopts foo=bar
+
+  options foo=bar $kernelopts
+
+  options $kernelopts $debugopts
+
+Also change some of the tests to cover mixing variables and literals.
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
+(cherry picked from commit 78a98b9ebc789d9c9c701af95e65292d768eee59)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/blscfg.c                      | 85 ++++++++++++++++----
+ test/parser/test-grub2-blscfg-multiple-bls.c |  5 +-
+ test/parser/test-grub2-blscfg-opts-grubenv.c |  4 +-
+ 3 files changed, 74 insertions(+), 20 deletions(-)
+
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+index 8ab016b..bc3dc88 100644
+--- a/discover/grub2/blscfg.c
++++ b/discover/grub2/blscfg.c
+@@ -2,6 +2,7 @@
+ #define _GNU_SOURCE
+ 
+ #include <assert.h>
++#include <ctype.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <dirent.h>
+@@ -34,54 +35,106 @@ struct bls_state {
+ 	const char *dtb;
+ };
+ 
++static char *field_append(struct bls_state *state, int type, char *buffer,
++			  char *start, char *end)
++{
++	char *temp = talloc_strndup(state, start, end - start + 1);
++	const char *field = temp;
++
++	if (type == GRUB2_WORD_VAR) {
++		field = script_env_get(state->script, temp);
++		if (!field)
++			return buffer;
++	}
++
++	if (!buffer)
++		buffer = talloc_strdup(state->opt, field);
++	else
++		buffer = talloc_asprintf_append(buffer, "%s", field);
++
++	return buffer;
++}
++
++static char *expand_field(struct bls_state *state, char *value)
++{
++	char *buffer = NULL;
++	char *start = value;
++	char *end = value;
++	int type = GRUB2_WORD_TEXT;
++
++	while (*value) {
++		if (*value == '$') {
++			if (start != end) {
++				buffer = field_append(state, type, buffer,
++						      start, end);
++				if (!buffer)
++					return NULL;
++			}
++
++			type = GRUB2_WORD_VAR;
++			start = value + 1;
++		} else if (type == GRUB2_WORD_VAR) {
++			if (!isalnum(*value) && *value != '_') {
++				buffer = field_append(state, type, buffer,
++						      start, end);
++				type = GRUB2_WORD_TEXT;
++				start = value;
++			}
++		}
++
++		end = value;
++		value++;
++	}
++
++	if (start != end) {
++		buffer = field_append(state, type, buffer,
++				      start, end);
++		if (!buffer)
++			return NULL;
++	}
++
++	return buffer;
++}
++
+ static void bls_process_pair(struct conf_context *conf, const char *name,
+ 			     char *value)
+ {
+ 	struct bls_state *state = conf->parser_info;
+ 	struct discover_boot_option *opt = state->opt;
+ 	struct boot_option *option = opt->option;
+-	const char *boot_args;
+ 
+ 	if (streq(name, "title")) {
+-		state->title = talloc_strdup(state, value);
++		state->title = expand_field(state, value);
+ 		return;
+ 	}
+ 
+ 	if (streq(name, "version")) {
+-		state->version = talloc_strdup(state, value);
++		state->version = expand_field(state, value);
+ 		return;
+ 	}
+ 
+ 	if (streq(name, "machine-id")) {
+-		state->machine_id = talloc_strdup(state, value);
++		state->machine_id = expand_field(state, value);
+ 		return;
+ 	}
+ 
+ 	if (streq(name, "linux")) {
+-		state->image = talloc_strdup(state, value);
++		state->image = expand_field(state, value);
+ 		return;
+ 	}
+ 
+ 	if (streq(name, "initrd")) {
+-		state->initrd = talloc_strdup(state, value);
++		state->initrd = expand_field(state, value);
+ 		return;
+ 	}
+ 
+ 	if (streq(name, "devicetree")) {
+-		state->dtb = talloc_strdup(state, value);
++		state->dtb = expand_field(state, value);
+ 		return;
+ 	}
+ 
+ 	if (streq(name, "options")) {
+-		if (value[0] == '$') {
+-			boot_args = script_env_get(state->script, value + 1);
+-			if (!boot_args)
+-				return;
+-
+-			option->boot_args = talloc_strdup(opt, boot_args);
+-		} else {
+-			option->boot_args = talloc_strdup(opt, value);
+-		}
++		option->boot_args = expand_field(state, value);
+ 		return;
+ 	}
+ }
+diff --git a/test/parser/test-grub2-blscfg-multiple-bls.c b/test/parser/test-grub2-blscfg-multiple-bls.c
+index 94f40d1..d15fb24 100644
+--- a/test/parser/test-grub2-blscfg-multiple-bls.c
++++ b/test/parser/test-grub2-blscfg-multiple-bls.c
+@@ -1,6 +1,7 @@
+ #include "parser-test.h"
+ 
+ #if 0 /* PARSER_EMBEDDED_CONFIG */
++set os_name=Fedora
+ blscfg
+ #endif
+ 
+@@ -13,14 +14,14 @@ void run_test(struct parser_test *test)
+ 
+ 	test_add_file_string(test, test->ctx->device,
+ 			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.15.2-302.fc28.x86_64.conf",
+-			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "title $os_name (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
+ 			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
+ 			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
+ 			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n\n");
+ 
+ 	test_add_file_string(test, test->ctx->device,
+ 			     "/loader/entries/6c063c8e48904f2684abde8eea303f41-4.14.18-300.fc28.x86_64.conf",
+-			     "title Fedora (4.14.18-300.fc28.x86_64) 28 (Twenty Eight)\n"
++			     "title $os_name (4.14.18-300.fc28.x86_64) 28 (Twenty Eight)\n"
+ 			     "linux /vmlinuz-4.14.18-300.fc28.x86_64\n"
+ 			     "initrd /initramfs-4.14.18-300.fc28.x86_64.img\n"
+ 			     "options root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root\n");
+diff --git a/test/parser/test-grub2-blscfg-opts-grubenv.c b/test/parser/test-grub2-blscfg-opts-grubenv.c
+index 544a5de..2dffd1b 100644
+--- a/test/parser/test-grub2-blscfg-opts-grubenv.c
++++ b/test/parser/test-grub2-blscfg-opts-grubenv.c
+@@ -22,7 +22,7 @@ void run_test(struct parser_test *test)
+ 			     "title Fedora (4.15.2-302.fc28.x86_64) 28 (Twenty Eight)\n"
+ 			     "linux /vmlinuz-4.15.2-302.fc28.x86_64\n"
+ 			     "initrd /initramfs-4.15.2-302.fc28.x86_64.img\n"
+-			     "options $kernelopts\n");
++			     "options $kernelopts debug\n");
+ 
+ 	test_read_conf_embedded(test, "/boot/grub2/grub.cfg");
+ 
+@@ -32,5 +32,5 @@ void run_test(struct parser_test *test)
+ 
+ 	opt = get_boot_option(ctx, 0);
+ 
+-	check_args(opt, "root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root");
++	check_args(opt, "root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root debug");
+ }
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-09-discover-grub2-search-set-variable-defaults-to-root.patch
+++ b/openpower/package/petitboot/petitboot-09-discover-grub2-search-set-variable-defaults-to-root.patch
@@ -1,0 +1,40 @@
+From c8bd1a785d9bb5c2c16a02f11aaac25a454454fd Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Thu, 31 Oct 2019 13:56:42 +0800
+Subject: [PATCH 10/23] discover/grub2: 'search' set-variable defaults to root
+
+If no --set= argument is specified, default to the variable named
+'root', as per current grub docs.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit e558da19475d747e6f8e83d07305d35da33102f9)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/builtins.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/discover/grub2/builtins.c b/discover/grub2/builtins.c
+index e42821a..d34e1d7 100644
+--- a/discover/grub2/builtins.c
++++ b/discover/grub2/builtins.c
+@@ -113,7 +113,7 @@ static int builtin_search(struct grub2_script *script,
+ 	const char *env_var, *spec;
+ 	int i;
+ 
+-	env_var = NULL;
++	env_var = "root";
+ 
+ 	for (i = 1; i < argc - 1; i++) {
+ 		if (!strncmp(argv[i], "--set=", strlen("--set="))) {
+@@ -122,7 +122,7 @@ static int builtin_search(struct grub2_script *script,
+ 		}
+ 	}
+ 
+-	if (!env_var)
++	if (!strlen(env_var))
+ 		return 0;
+ 
+ 	spec = argv[argc - 1];
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-10-discover-grub2-Use-getopt-for-search-argument-parsin.patch
+++ b/openpower/package/petitboot/petitboot-10-discover-grub2-Use-getopt-for-search-argument-parsin.patch
@@ -1,0 +1,142 @@
+From 7c870324f65bce732db6f225f67aa89eef491909 Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Thu, 31 Oct 2019 17:31:10 +0800
+Subject: [PATCH 11/23] discover/grub2: Use getopt for `search` argument
+ parsing
+
+The search command will be extended to add the full set of grub2-style
+arguments, so switch to using getopt, rather than manual parsing.
+
+This means we now support `--set=foo` and `--set foo` style arguments,
+both of which appear in the docs and common grub configs.
+
+Also, add a small test for the search argument handling.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 61ede5e0bea7d999acfdda9931e5c1f3c13c0694)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/builtins.c            | 33 +++++++++++++++++++++++-----
+ test/parser/Makefile.am              |  1 +
+ test/parser/test-grub2-search-args.c | 33 ++++++++++++++++++++++++++++
+ 3 files changed, 62 insertions(+), 5 deletions(-)
+ create mode 100644 test/parser/test-grub2-search-args.c
+
+diff --git a/discover/grub2/builtins.c b/discover/grub2/builtins.c
+index d34e1d7..720e3e9 100644
+--- a/discover/grub2/builtins.c
++++ b/discover/grub2/builtins.c
+@@ -1,4 +1,7 @@
+ 
++#define _GNU_SOURCE
++
++#include <getopt.h>
+ #include <stdio.h>
+ #include <string.h>
+ 
+@@ -106,18 +109,35 @@ static int builtin_initrd(struct grub2_script *script,
+ 	return 0;
+ }
+ 
++static const struct option search_options[] = {
++	{
++		.name = "set",
++		.has_arg = required_argument,
++		.val = 's',
++	},
++	{ 0 },
++};
++
+ static int builtin_search(struct grub2_script *script,
+ 		void *data __attribute__((unused)),
+ 		int argc, char *argv[])
+ {
+ 	const char *env_var, *spec;
+-	int i;
+ 
+ 	env_var = "root";
++	optind = 0;
++
++	for (;;) {
++		int c = getopt_long(argc, argv, ":", search_options, NULL);
++		if (c == -1)
++			break;
+ 
+-	for (i = 1; i < argc - 1; i++) {
+-		if (!strncmp(argv[i], "--set=", strlen("--set="))) {
+-			env_var = argv[i] + strlen("--set=");
++		switch (c) {
++		case 's':
++			env_var = optarg;
++			break;
++		case '?':
++		case ':':
+ 			break;
+ 		}
+ 	}
+@@ -125,7 +145,10 @@ static int builtin_search(struct grub2_script *script,
+ 	if (!strlen(env_var))
+ 		return 0;
+ 
+-	spec = argv[argc - 1];
++	if (optind >= argc)
++		return -1;
++
++	spec = argv[optind];
+ 
+ 	script_env_set(script, env_var, spec);
+ 
+diff --git a/test/parser/Makefile.am b/test/parser/Makefile.am
+index 2fc19fa..8e972cd 100644
+--- a/test/parser/Makefile.am
++++ b/test/parser/Makefile.am
+@@ -27,6 +27,7 @@ parser_TESTS = \
+ 	test/parser/test-grub2-multiple-id \
+ 	test/parser/test-grub2-single-line-if \
+ 	test/parser/test-grub2-pos-param \
++	test/parser/test-grub2-search-args \
+ 	test/parser/test-grub2-load-env \
+ 	test/parser/test-grub2-save-env \
+ 	test/parser/test-grub2-save-env-dash-f \
+diff --git a/test/parser/test-grub2-search-args.c b/test/parser/test-grub2-search-args.c
+new file mode 100644
+index 0000000..ffce853
+--- /dev/null
++++ b/test/parser/test-grub2-search-args.c
+@@ -0,0 +1,33 @@
++
++/* check for multiple styles of option parsing for the 'search' command */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++# no --set arugment will set the 'root' var
++search a
++search --set=v1 b
++search --set v2 c
++
++menuentry $root$v1$v2 {
++    linux /vmlinux
++}
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	ctx = test->ctx;
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 1);
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "abc");
++}
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-11-discover-grub2-test-for-ignored-no-floppy-argument.patch
+++ b/openpower/package/petitboot/petitboot-11-discover-grub2-test-for-ignored-no-floppy-argument.patch
@@ -1,0 +1,41 @@
+From 919578c645428d925e052a3b52087f404dceb8bd Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Fri, 1 Nov 2019 07:18:08 +0800
+Subject: [PATCH 12/23] discover/grub2: test for (ignored) --no-floppy argument
+
+--no-floppy is used almost everywhere, so add it to the tests. The code
+will already ignore unknown arguments, but ensure that this works OK.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 76e97c5d9dab40236a589cd96a69967d3ef17cab)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ test/parser/test-grub2-search-args.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/test/parser/test-grub2-search-args.c b/test/parser/test-grub2-search-args.c
+index ffce853..0eb5762 100644
+--- a/test/parser/test-grub2-search-args.c
++++ b/test/parser/test-grub2-search-args.c
+@@ -9,8 +9,10 @@
+ search a
+ search --set=v1 b
+ search --set v2 c
++search --set=v3 --no-floppy d
++search --no-floppy --set=v4 e
+ 
+-menuentry $root$v1$v2 {
++menuentry $root$v1$v2$v3$v4 {
+     linux /vmlinux
+ }
+ 
+@@ -29,5 +31,5 @@ void run_test(struct parser_test *test)
+ 
+ 	check_boot_option_count(ctx, 1);
+ 	opt = get_boot_option(ctx, 0);
+-	check_name(opt, "abc");
++	check_name(opt, "abcde");
+ }
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-12-discover-grub2-Add-support-for-UUID-and-label-for-se.patch
+++ b/openpower/package/petitboot/petitboot-12-discover-grub2-Add-support-for-UUID-and-label-for-se.patch
@@ -1,0 +1,245 @@
+From c8c71334ccb75e42c58bf8e4267910dd558761f1 Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Mon, 4 Nov 2019 14:58:01 +0800
+Subject: [PATCH 13/23] discover/grub2: Add support for UUID and label for
+ 'search' command
+
+This change adds support for searching by UUID and filesystem label.
+We still fall back to passthrough if the UUID is not found, but we now
+resolve to device ID strings.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 1580c6557d4e703348edb0dda83814f8972e9f3d)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/builtins.c             | 55 +++++++++++++++++++++++++--
+ test/parser/Makefile.am               |  2 +
+ test/parser/test-grub2-search-label.c | 47 +++++++++++++++++++++++
+ test/parser/test-grub2-search-uuid.c  | 55 +++++++++++++++++++++++++++
+ 4 files changed, 156 insertions(+), 3 deletions(-)
+ create mode 100644 test/parser/test-grub2-search-label.c
+ create mode 100644 test/parser/test-grub2-search-uuid.c
+
+diff --git a/discover/grub2/builtins.c b/discover/grub2/builtins.c
+index 720e3e9..9841648 100644
+--- a/discover/grub2/builtins.c
++++ b/discover/grub2/builtins.c
+@@ -115,6 +115,21 @@ static const struct option search_options[] = {
+ 		.has_arg = required_argument,
+ 		.val = 's',
+ 	},
++	{
++		.name = "file",
++		.has_arg = no_argument,
++		.val = 'f',
++	},
++	{
++		.name = "label",
++		.has_arg = no_argument,
++		.val = 'l',
++	},
++	{
++		.name = "fs-uuid",
++		.has_arg = no_argument,
++		.val = 'u',
++	},
+ 	{ 0 },
+ };
+ 
+@@ -122,13 +137,23 @@ static int builtin_search(struct grub2_script *script,
+ 		void *data __attribute__((unused)),
+ 		int argc, char *argv[])
+ {
+-	const char *env_var, *spec;
++	const char *env_var, *spec, *res;
++	struct discover_device *dev;
++	enum {
++		LOOKUP_UUID = 'u',
++		LOOKUP_LABEL = 'l',
++		LOOKUP_FILE = 'f',
++	} lookup_type;
+ 
+ 	env_var = "root";
+ 	optind = 0;
+ 
++	/* Default to UUID, for backwards compat with earlier petitboot
++	 * versions. This argument is non-optional in GRUB. */
++	lookup_type = LOOKUP_UUID;
++
+ 	for (;;) {
+-		int c = getopt_long(argc, argv, ":", search_options, NULL);
++		int c = getopt_long(argc, argv, ":flu", search_options, NULL);
+ 		if (c == -1)
+ 			break;
+ 
+@@ -136,6 +161,11 @@ static int builtin_search(struct grub2_script *script,
+ 		case 's':
+ 			env_var = optarg;
+ 			break;
++		case LOOKUP_UUID:
++		case LOOKUP_LABEL:
++		case LOOKUP_FILE:
++			lookup_type = c;
++			break;
+ 		case '?':
+ 		case ':':
+ 			break;
+@@ -149,8 +179,27 @@ static int builtin_search(struct grub2_script *script,
+ 		return -1;
+ 
+ 	spec = argv[optind];
++	res = NULL;
++
++	switch (lookup_type) {
++	case LOOKUP_UUID:
++		dev = device_lookup_by_uuid(script->ctx->handler,
++				spec);
++		res = dev ? dev->device->id : spec;
++		break;
++	case LOOKUP_LABEL:
++		dev = device_lookup_by_label(script->ctx->handler,
++				spec);
++		if (dev)
++			res = dev->device->id;
++		break;
++	case LOOKUP_FILE:
++		/* not yet implemented */
++		break;
++	}
+ 
+-	script_env_set(script, env_var, spec);
++	if (res)
++		script_env_set(script, env_var, res);
+ 
+ 	return 0;
+ }
+diff --git a/test/parser/Makefile.am b/test/parser/Makefile.am
+index 8e972cd..846ed5b 100644
+--- a/test/parser/Makefile.am
++++ b/test/parser/Makefile.am
+@@ -28,6 +28,8 @@ parser_TESTS = \
+ 	test/parser/test-grub2-single-line-if \
+ 	test/parser/test-grub2-pos-param \
+ 	test/parser/test-grub2-search-args \
++	test/parser/test-grub2-search-uuid \
++	test/parser/test-grub2-search-label \
+ 	test/parser/test-grub2-load-env \
+ 	test/parser/test-grub2-save-env \
+ 	test/parser/test-grub2-save-env-dash-f \
+diff --git a/test/parser/test-grub2-search-label.c b/test/parser/test-grub2-search-label.c
+new file mode 100644
+index 0000000..b9ee034
+--- /dev/null
++++ b/test/parser/test-grub2-search-label.c
+@@ -0,0 +1,47 @@
++/* check for grub2 search command, searching by partition label */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++# valid label
++search --set=v1 --label testlabel
++
++v2=prev
++# invalid label: does not alter v2
++search --set=v2 --label invalidlabel
++
++menuentry $v1 {
++    linux /vmlinux
++}
++
++menuentry $v2 {
++    linux /vmlinux
++}
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++	struct discover_device *dev;
++
++	ctx = test->ctx;
++
++	dev = test_create_device(test, "testdev");
++	dev->label = "testlabel";
++	device_handler_add_device(test->handler, dev);
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 2);
++
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "testdev");
++
++	opt = get_boot_option(ctx, 1);
++	check_name(opt, "prev");
++}
+diff --git a/test/parser/test-grub2-search-uuid.c b/test/parser/test-grub2-search-uuid.c
+new file mode 100644
+index 0000000..7eacd1d
+--- /dev/null
++++ b/test/parser/test-grub2-search-uuid.c
+@@ -0,0 +1,55 @@
++/* check for grub2 search command, searching by FS UUID */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++# valid UUID
++search --set=v1 --fs-uuid ee0cc6fa-1dba-48f2-8f5b-19e4b8de8c37
++
++# invalid UUID: will fall back to passing the UUID through
++search --set=v2 --fs-uuid 92b0da57-6e04-4e54-960b-85e6bb060433
++
++# no 'type' argument defaults to UUID search
++search --set=v3 ee0cc6fa-1dba-48f2-8f5b-19e4b8de8c37
++
++menuentry $v1 {
++    linux /vmlinux
++}
++
++menuentry $v2 {
++    linux /vmlinux
++}
++
++menuentry $v3 {
++    linux /vmlinux
++}
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++	struct discover_device *dev;
++
++	ctx = test->ctx;
++
++	dev = test_create_device(test, "testdev");
++	dev->uuid = "ee0cc6fa-1dba-48f2-8f5b-19e4b8de8c37";
++	device_handler_add_device(test->handler, dev);
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 3);
++
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, dev->device->id);
++
++	opt = get_boot_option(ctx, 1);
++	check_name(opt, "92b0da57-6e04-4e54-960b-85e6bb060433");
++
++	opt = get_boot_option(ctx, 2);
++	check_name(opt, dev->device->id);
++}
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-13-discover-grub2-expose-a-struct-for-grub2-file-refere.patch
+++ b/openpower/package/petitboot/petitboot-13-discover-grub2-expose-a-struct-for-grub2-file-refere.patch
@@ -1,0 +1,112 @@
+From 23e74b66e1237f05967ee564a427c2018bbf2948 Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Tue, 5 Nov 2019 16:42:14 +0800
+Subject: [PATCH 14/23] discover/grub2: expose a struct for grub2 file
+ references
+
+Currently, we have struct grub2_resource_info to keep references to boot
+payloads that may be returned in boot options, and be (conditionally)
+resolved by the parser.
+
+We'd also like to use the same semantics for other file references in
+the grub2 parser, for arbitrary usage in scripts - where files are
+also referenced by a path and an optional device.
+
+To do this, this change moves struct grub2_resource_info to grub2.h, and
+renames to struct grub2_file. Future changes will use this for
+script-internal file handling.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 8cb74c4502712162ba899bc06e2d0cf249a8697b)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/grub2.c | 24 +++++++++---------------
+ discover/grub2/grub2.h |  8 ++++++++
+ 2 files changed, 17 insertions(+), 15 deletions(-)
+
+diff --git a/discover/grub2/grub2.c b/discover/grub2/grub2.c
+index f62ccdd..412298b 100644
+--- a/discover/grub2/grub2.c
++++ b/discover/grub2/grub2.c
+@@ -33,17 +33,12 @@ static const char *const grub2_conf_files[] = {
+ 	NULL
+ };
+ 
+-struct grub2_resource_info {
+-	char *root;
+-	char *path;
+-};
+-
+ /* we use slightly different resources for grub2 */
+ struct resource *create_grub2_resource(struct discover_boot_option *opt,
+ 		struct discover_device *orig_device,
+ 		const char *root, const char *path)
+ {
+-	struct grub2_resource_info *info;
++	struct grub2_file *file;
+ 	struct resource *res;
+ 
+ 	if (strstr(path, "://")) {
+@@ -55,13 +50,12 @@ struct resource *create_grub2_resource(struct discover_boot_option *opt,
+ 	res = talloc(opt, struct resource);
+ 
+ 	if (root) {
+-		info = talloc(res, struct grub2_resource_info);
+-		talloc_reference(info, root);
+-		info->root = talloc_strdup(info, root);
+-		info->path = talloc_strdup(info, path);
++		file = talloc(res, struct grub2_file);
++		file->dev = talloc_strdup(file, root);
++		file->path = talloc_strdup(file, path);
+ 
+ 		res->resolved = false;
+-		res->info = info;
++		res->info = file;
+ 
+ 	} else
+ 		resolve_resource_against_device(res, orig_device, path);
+@@ -72,18 +66,18 @@ struct resource *create_grub2_resource(struct discover_boot_option *opt,
+ bool resolve_grub2_resource(struct device_handler *handler,
+ 		struct resource *res)
+ {
+-	struct grub2_resource_info *info = res->info;
++	struct grub2_file *file = res->info;
+ 	struct discover_device *dev;
+ 
+ 	assert(!res->resolved);
+ 
+-	dev = device_lookup_by_uuid(handler, info->root);
++	dev = device_lookup_by_uuid(handler, file->dev);
+ 
+ 	if (!dev)
+ 		return false;
+ 
+-	resolve_resource_against_device(res, dev, info->path);
+-	talloc_free(info);
++	resolve_resource_against_device(res, dev, file->path);
++	talloc_free(file);
+ 
+ 	return true;
+ }
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index 68176fb..73d91b2 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -107,6 +107,14 @@ struct grub2_parser {
+ 	bool			inter_word;
+ };
+ 
++/* References to files in grub2 consist of an optional device and a path
++ * (specified here by UUID). If the dev is unspecified, we fall back to a
++ * default - usually the 'root' environment variable. */
++struct grub2_file {
++	char *dev;
++	char *path;
++};
++
+ /* type for builtin functions */
+ typedef int (*grub2_function)(struct grub2_script *script, void *data,
+ 				int argc, char *argv[]);
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-14-discover-grub2-Add-parsing-code-for-grub2-file-speci.patch
+++ b/openpower/package/petitboot/petitboot-14-discover-grub2-Add-parsing-code-for-grub2-file-speci.patch
@@ -1,0 +1,84 @@
+From d5459b2ab020880756bac0f7defd86843d91a429 Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Wed, 6 Nov 2019 11:04:54 +0800
+Subject: [PATCH 15/23] discover/grub2: Add parsing code for grub2 file
+ specifiers
+
+This change adds a (currently unused) function to parse (device)/path
+references from grub scripts.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 51f71178cd82a1cb7fae1a4e6bf40290e41b7d0e)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/grub2.c | 38 ++++++++++++++++++++++++++++++++++++++
+ discover/grub2/grub2.h |  4 ++++
+ 2 files changed, 42 insertions(+)
+
+diff --git a/discover/grub2/grub2.c b/discover/grub2/grub2.c
+index 412298b..3873720 100644
+--- a/discover/grub2/grub2.c
++++ b/discover/grub2/grub2.c
+@@ -82,6 +82,44 @@ bool resolve_grub2_resource(struct device_handler *handler,
+ 	return true;
+ }
+ 
++struct grub2_file *grub2_parse_file(struct grub2_script *script,
++		const char *str)
++{
++	struct grub2_file *file;
++	size_t dev_len;
++	char *pos;
++
++	if (!str)
++		return NULL;
++
++	file = talloc_zero(script, struct grub2_file);
++
++	if (*str != '(') {
++		/* just a path - no device, return path as-is */
++		file->path = talloc_strdup(file, str);
++
++	} else {
++		/* device plus path - split into components */
++
++		pos = strchr(str, ')');
++
++		/* no closing bracket, or zero-length path? */
++		if (!pos || *(pos+1) == '\0') {
++			talloc_free(file);
++			return NULL;
++		}
++
++		file->path = talloc_strdup(file, pos + 1);
++
++		dev_len = pos - str - 1;
++		if (dev_len)
++			file->dev = talloc_strndup(file, str + 1, dev_len);
++	}
++
++	return file;
++}
++
++
+ static int grub2_parse(struct discover_context *dc)
+ {
+ 	const char * const *filename;
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index 73d91b2..8c4839b 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -198,6 +198,10 @@ struct resource *create_grub2_resource(struct discover_boot_option *opt,
+ bool resolve_grub2_resource(struct device_handler *handler,
+ 		struct resource *res);
+ 
++/* grub-style device+path parsing */
++struct grub2_file *grub2_parse_file(struct grub2_script *script,
++		const char *str);
++
+ /* external parser api */
+ struct grub2_parser *grub2_parser_create(struct discover_context *ctx);
+ void grub2_parser_parse(struct grub2_parser *parser, const char *filename,
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-15-discover-grub2-add-support-for-grub2-style-path-spec.patch
+++ b/openpower/package/petitboot/petitboot-15-discover-grub2-add-support-for-grub2-style-path-spec.patch
@@ -1,0 +1,340 @@
+From 46ffd51a477d374396e1fceac7b851693e03af5f Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Mon, 11 Nov 2019 17:10:30 +0800
+Subject: [PATCH 16/23] discover/grub2: add support for grub2-style path
+ specifiers in resources
+
+This change incorporates the grub2-style (device)/path specifiers in the
+grub2 parser's resource code. This allows the boot option paths to use
+device-specific references.
+
+Device names are looked-up using the UUID and kernel IDs, but with the
+lookup logic specific to a new function (grub2_lookup_device), so that
+can be extended in a future change.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 9fc2ac627df17ddc8e7c2735053aeb9e1252ff6e)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/blscfg.c          | 19 +++----
+ discover/grub2/builtins.c        | 15 ++----
+ discover/grub2/grub2.c           | 56 +++++++++++++++-----
+ discover/grub2/grub2.h           |  5 +-
+ test/parser/Makefile.am          |  1 +
+ test/parser/test-grub2-devpath.c | 88 ++++++++++++++++++++++++++++++++
+ 6 files changed, 147 insertions(+), 37 deletions(-)
+ create mode 100644 test/parser/test-grub2-devpath.c
+
+diff --git a/discover/grub2/blscfg.c b/discover/grub2/blscfg.c
+index bc3dc88..deb6429 100644
+--- a/discover/grub2/blscfg.c
++++ b/discover/grub2/blscfg.c
+@@ -166,7 +166,6 @@ static void bls_finish(struct conf_context *conf)
+ 	struct discover_context *dc = conf->dc;
+ 	struct discover_boot_option *opt = state->opt;
+ 	struct boot_option *option = opt->option;
+-	const char *root;
+ 	char *filename;
+ 
+ 	if (!state->image) {
+@@ -192,23 +191,21 @@ static void bls_finish(struct conf_context *conf)
+ 	else
+ 		option->name = talloc_strdup(option, state->image);
+ 
+-	root = script_env_get(state->script, "root");
+-
+-	opt->boot_image = create_grub2_resource(opt, conf->dc->device,
+-						root, state->image);
++	opt->boot_image = create_grub2_resource(state->script, opt,
++						state->image);
+ 
+ 	if (state->initrd)
+-		opt->initrd = create_grub2_resource(opt, conf->dc->device,
+-						    root, state->initrd);
++		opt->initrd = create_grub2_resource(state->script, opt,
++						    state->initrd);
+ 
+ 	if (state->dtb)
+-		opt->dtb = create_grub2_resource(opt, conf->dc->device,
+-						 root, state->dtb);
++		opt->dtb = create_grub2_resource(state->script, opt,
++						 state->dtb);
+ 
+ 	char* args_sigfile_default = talloc_asprintf(opt,
+ 		"%s.cmdline.sig", state->image);
+-	opt->args_sig_file = create_grub2_resource(opt, conf->dc->device,
+-						root, args_sigfile_default);
++	opt->args_sig_file = create_grub2_resource(state->script, opt,
++						args_sigfile_default);
+ 	talloc_free(args_sigfile_default);
+ 
+ 	option->is_default = option_is_default(state, option);
+diff --git a/discover/grub2/builtins.c b/discover/grub2/builtins.c
+index 9841648..ca13880 100644
+--- a/discover/grub2/builtins.c
++++ b/discover/grub2/builtins.c
+@@ -46,7 +46,6 @@ static int builtin_linux(struct grub2_script *script,
+ 		int argc, char *argv[])
+ {
+ 	struct discover_boot_option *opt = script->opt;
+-	const char *root;
+ 	int i;
+ 
+ 	if (!opt) {
+@@ -61,10 +60,7 @@ static int builtin_linux(struct grub2_script *script,
+ 		return -1;
+ 	}
+ 
+-	root = script_env_get(script, "root");
+-
+-	opt->boot_image = create_grub2_resource(opt, script->ctx->device,
+-						root, argv[1]);
++	opt->boot_image = create_grub2_resource(script, opt, argv[1]);
+ 	opt->option->boot_args = NULL;
+ 
+ 	if (argc > 2)
+@@ -77,8 +73,8 @@ static int builtin_linux(struct grub2_script *script,
+ 
+ 	char* args_sigfile_default = talloc_asprintf(opt,
+ 		"%s.cmdline.sig", argv[1]);
+-	opt->args_sig_file = create_grub2_resource(opt, script->ctx->device,
+-						root, args_sigfile_default);
++	opt->args_sig_file = create_grub2_resource(script, opt,
++						args_sigfile_default);
+ 	talloc_free(args_sigfile_default);
+ 	return 0;
+ }
+@@ -88,7 +84,6 @@ static int builtin_initrd(struct grub2_script *script,
+ 		int argc, char *argv[])
+ {
+ 	struct discover_boot_option *opt = script->opt;
+-	const char *root;
+ 
+ 	if (!opt) {
+ 		pb_log("grub2 syntax error: 'initrd' statement outside "
+@@ -102,9 +97,7 @@ static int builtin_initrd(struct grub2_script *script,
+ 		return -1;
+ 	}
+ 
+-	root = script_env_get(script, "root");
+-	opt->initrd = create_grub2_resource(opt, script->ctx->device,
+-						root, argv[1]);
++	opt->initrd = create_grub2_resource(script, opt, argv[1]);
+ 
+ 	return 0;
+ }
+diff --git a/discover/grub2/grub2.c b/discover/grub2/grub2.c
+index 3873720..a08a320 100644
+--- a/discover/grub2/grub2.c
++++ b/discover/grub2/grub2.c
+@@ -33,13 +33,35 @@ static const char *const grub2_conf_files[] = {
+ 	NULL
+ };
+ 
++static struct discover_device *grub2_lookup_device(
++		struct device_handler *handler, const char *desc)
++{
++	struct discover_device *dev;
++
++	if (!desc || !*desc)
++		return NULL;
++
++	dev = device_lookup_by_id(handler, desc);
++	if (dev)
++		return dev;
++
++	/* for now, only lookup by UUID */
++	dev = device_lookup_by_uuid(handler, desc);
++	if (dev)
++		return dev;
++
++	return NULL;
++}
++
+ /* we use slightly different resources for grub2 */
+-struct resource *create_grub2_resource(struct discover_boot_option *opt,
+-		struct discover_device *orig_device,
+-		const char *root, const char *path)
++struct resource *create_grub2_resource(struct grub2_script *script,
++		struct discover_boot_option *opt,
++		const char *path)
+ {
++	struct discover_device *dev;
+ 	struct grub2_file *file;
+ 	struct resource *res;
++	const char *root;
+ 
+ 	if (strstr(path, "://")) {
+ 		struct pb_url *url = pb_url_parse(opt, path);
+@@ -47,18 +69,29 @@ struct resource *create_grub2_resource(struct discover_boot_option *opt,
+ 			return create_url_resource(opt, url);
+ 	}
+ 
++	file = grub2_parse_file(script, path);
++	if (!file)
++		return NULL;
++
+ 	res = talloc(opt, struct resource);
++	root = script_env_get(script, "root");
+ 
+-	if (root) {
+-		file = talloc(res, struct grub2_file);
++	if (!file->dev && root && strlen(root))
+ 		file->dev = talloc_strdup(file, root);
+-		file->path = talloc_strdup(file, path);
+ 
+-		res->resolved = false;
+-		res->info = file;
++	/* if we don't have a device specified, or the lookup succeeds now,
++	 * then we can resolve the resource right away */
++	if (file->dev)
++		dev = grub2_lookup_device(script->ctx->handler, file->dev);
++	else
++		dev = script->ctx->device;
+ 
+-	} else
+-		resolve_resource_against_device(res, orig_device, path);
++	if (dev) {
++		resolve_resource_against_device(res, dev, file->path);
++	} else {
++		res->resolved = false;
++		res->info = talloc_steal(opt, file);
++	}
+ 
+ 	return res;
+ }
+@@ -71,8 +104,7 @@ bool resolve_grub2_resource(struct device_handler *handler,
+ 
+ 	assert(!res->resolved);
+ 
+-	dev = device_lookup_by_uuid(handler, file->dev);
+-
++	dev = grub2_lookup_device(handler, file->dev);
+ 	if (!dev)
+ 		return false;
+ 
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index 8c4839b..ef32d4b 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -191,9 +191,8 @@ void script_register_function(struct grub2_script *script,
+ void register_builtins(struct grub2_script *script);
+ 
+ /* resources */
+-struct resource *create_grub2_resource(struct discover_boot_option *opt,
+-		struct discover_device *orig_device,
+-		const char *root, const char *path);
++struct resource *create_grub2_resource(struct grub2_script *script,
++		struct discover_boot_option *opt, const char *path);
+ 
+ bool resolve_grub2_resource(struct device_handler *handler,
+ 		struct resource *res);
+diff --git a/test/parser/Makefile.am b/test/parser/Makefile.am
+index 846ed5b..7ddb01f 100644
+--- a/test/parser/Makefile.am
++++ b/test/parser/Makefile.am
+@@ -30,6 +30,7 @@ parser_TESTS = \
+ 	test/parser/test-grub2-search-args \
+ 	test/parser/test-grub2-search-uuid \
+ 	test/parser/test-grub2-search-label \
++	test/parser/test-grub2-devpath \
+ 	test/parser/test-grub2-load-env \
+ 	test/parser/test-grub2-save-env \
+ 	test/parser/test-grub2-save-env-dash-f \
+diff --git a/test/parser/test-grub2-devpath.c b/test/parser/test-grub2-devpath.c
+new file mode 100644
+index 0000000..d1d00f1
+--- /dev/null
++++ b/test/parser/test-grub2-devpath.c
+@@ -0,0 +1,88 @@
++/* check grub2 device+path string parsing */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++# local
++menuentry a {
++	linux /vmlinux
++}
++
++# local, specified by root env var
++root=00000000-0000-0000-0000-000000000001
++menuentry b {
++	linux /vmlinux
++}
++
++# remote, specified by root env var
++root=00000000-0000-0000-0000-000000000002
++menuentry c {
++	linux /vmlinux
++}
++
++# local, full dev+path spec
++menuentry d {
++	linux (00000000-0000-0000-0000-000000000001)/vmlinux
++}
++
++# remote, full dev+path spec
++menuentry e {
++	linux (00000000-0000-0000-0000-000000000002)/vmlinux
++}
++
++# invalid: incomplete dev+path spec
++menuentry f {
++	linux (00000000-0000-0000-0000-000000000001
++}
++
++# invalid: no path
++menuentry g {
++	linux (00000000-0000-0000-0000-000000000001)
++}
++
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_device *dev1, *dev2;
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	ctx = test->ctx;
++
++	/* set local uuid */
++	dev1 = test->ctx->device;
++	dev1->uuid = "00000000-0000-0000-0000-000000000001";
++
++	dev2 = test_create_device(test, "extdev");
++	dev2->uuid = "00000000-0000-0000-0000-000000000002";
++	device_handler_add_device(ctx->handler, dev2);
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 5);
++
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "a");
++	check_resolved_local_resource(opt->boot_image, dev1, "/vmlinux");
++
++	opt = get_boot_option(ctx, 1);
++	check_name(opt, "b");
++	check_resolved_local_resource(opt->boot_image, dev1, "/vmlinux");
++
++	opt = get_boot_option(ctx, 2);
++	check_name(opt, "c");
++	check_resolved_local_resource(opt->boot_image, dev2, "/vmlinux");
++
++	opt = get_boot_option(ctx, 3);
++	check_name(opt, "d");
++	check_resolved_local_resource(opt->boot_image, dev1, "/vmlinux");
++
++	opt = get_boot_option(ctx, 4);
++	check_name(opt, "e");
++	check_resolved_local_resource(opt->boot_image, dev2, "/vmlinux");
++}
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-16-discover-grub2-Allow-device-path-references-in-gener.patch
+++ b/openpower/package/petitboot/petitboot-16-discover-grub2-Allow-device-path-references-in-gener.patch
@@ -1,0 +1,214 @@
+From c05a8cb0bb540a61e82152f553d670f6147648cb Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Mon, 11 Nov 2019 19:30:41 +0800
+Subject: [PATCH 17/23] discover/grub2: Allow (device)/path references in
+ general script usage
+
+Currently, we have support for grub2 (device)/path syntax for boot
+resources. This change allows this syntax for general paths in grub2
+scripts (for example, -f tests).
+
+This involves exposing grub2_lookup_device, to allow the script
+execution code to resolve pathnames.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit b22445748f44ed6965f31f45b39abb690d24ec47)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/builtins.c                  | 50 ++++++++++++++++---
+ discover/grub2/grub2.c                     |  4 +-
+ discover/grub2/grub2.h                     |  2 +
+ test/parser/Makefile.am                    |  1 +
+ test/parser/test-grub2-devpath-scripting.c | 56 ++++++++++++++++++++++
+ 5 files changed, 104 insertions(+), 9 deletions(-)
+ create mode 100644 test/parser/test-grub2-devpath-scripting.c
+
+diff --git a/discover/grub2/builtins.c b/discover/grub2/builtins.c
+index ca13880..aab11ac 100644
+--- a/discover/grub2/builtins.c
++++ b/discover/grub2/builtins.c
+@@ -197,6 +197,32 @@ static int builtin_search(struct grub2_script *script,
+ 	return 0;
+ }
+ 
++static int parse_to_device_path(struct grub2_script *script,
++		const char *desc, struct discover_device **devp,
++		char **pathp)
++{
++	struct discover_device *dev;
++	struct grub2_file *file;
++
++	file = grub2_parse_file(script, desc);
++	if (!file)
++		return -1;
++
++	dev = script->ctx->device;
++	if (file->dev)
++		dev = grub2_lookup_device(script->ctx->handler, file->dev);
++
++	if (!dev)
++		return -1;
++
++	*devp = dev;
++	*pathp = talloc_strdup(script, file->path);
++
++	talloc_free(file);
++
++	return 0;
++}
++
+ /* Note that GRUB does not follow symlinks in evaluating all file
+  * tests but -s, unlike below. However, it seems like a bad idea to
+  * emulate GRUB's behavior (e.g., it would take extra work), so we
+@@ -204,12 +230,17 @@ static int builtin_search(struct grub2_script *script,
+ static bool builtin_test_op_file(struct grub2_script *script, char op,
+ 		const char *file)
+ {
++	struct discover_device *dev;
++	struct stat statbuf;
+ 	bool result;
++	char *path;
+ 	int rc;
+-	struct stat statbuf;
+ 
+-	rc = parser_stat_path(script->ctx, script->ctx->device,
+-			file, &statbuf);
++	rc = parse_to_device_path(script, file, &dev, &path);
++	if (rc)
++		return false;
++
++	rc = parser_stat_path(script->ctx, dev, path, &statbuf);
+ 	if (rc)
+ 		return false;
+ 
+@@ -237,16 +268,21 @@ static bool builtin_test_op_file(struct grub2_script *script, char op,
+ static bool builtin_test_op_dir(struct grub2_script *script, char op,
+ 		const char *dir)
+ {
+-	int rc;
++	struct discover_device *dev;
+ 	struct stat statbuf;
++	char *path;
++	int rc;
+ 
+ 	if (op != 'd')
+ 		return false;
+ 
+-	rc = parser_stat_path(script->ctx, script->ctx->device, dir, &statbuf);
+-	if (rc) {
++	rc = parse_to_device_path(script, dir, &dev, &path);
++	if (rc)
++		return false;
++
++	rc = parser_stat_path(script->ctx, dev, path, &statbuf);
++	if (rc)
+ 		return false;
+-	}
+ 
+ 	return S_ISDIR(statbuf.st_mode);
+ }
+diff --git a/discover/grub2/grub2.c b/discover/grub2/grub2.c
+index a08a320..a8d115f 100644
+--- a/discover/grub2/grub2.c
++++ b/discover/grub2/grub2.c
+@@ -33,8 +33,8 @@ static const char *const grub2_conf_files[] = {
+ 	NULL
+ };
+ 
+-static struct discover_device *grub2_lookup_device(
+-		struct device_handler *handler, const char *desc)
++struct discover_device *grub2_lookup_device(struct device_handler *handler,
++		const char *desc)
+ {
+ 	struct discover_device *dev;
+ 
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index ef32d4b..eabd6d6 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -200,6 +200,8 @@ bool resolve_grub2_resource(struct device_handler *handler,
+ /* grub-style device+path parsing */
+ struct grub2_file *grub2_parse_file(struct grub2_script *script,
+ 		const char *str);
++struct discover_device *grub2_lookup_device(struct device_handler *handler,
++		const char *desc);
+ 
+ /* external parser api */
+ struct grub2_parser *grub2_parser_create(struct discover_context *ctx);
+diff --git a/test/parser/Makefile.am b/test/parser/Makefile.am
+index 7ddb01f..1631d76 100644
+--- a/test/parser/Makefile.am
++++ b/test/parser/Makefile.am
+@@ -31,6 +31,7 @@ parser_TESTS = \
+ 	test/parser/test-grub2-search-uuid \
+ 	test/parser/test-grub2-search-label \
+ 	test/parser/test-grub2-devpath \
++	test/parser/test-grub2-devpath-scripting \
+ 	test/parser/test-grub2-load-env \
+ 	test/parser/test-grub2-save-env \
+ 	test/parser/test-grub2-save-env-dash-f \
+diff --git a/test/parser/test-grub2-devpath-scripting.c b/test/parser/test-grub2-devpath-scripting.c
+new file mode 100644
+index 0000000..9046ab6
+--- /dev/null
++++ b/test/parser/test-grub2-devpath-scripting.c
+@@ -0,0 +1,56 @@
++/* check grub2 device+path string parsing, as used in scripts */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++v=
++
++# local device, file present
++if [ -f "/1-present" ]; then v=${v}a; fi
++
++# local device, file absent
++if [ -f "/1-absent" ]; then v=${v}b; fi;
++
++# local device by UUID, file present
++if [ -f "(00000000-0000-0000-0000-000000000001)/1-present" ]; then v=${v}c; fi;
++
++# remote device by UUID, file present
++if [ -f "(00000000-0000-0000-0000-000000000002)/2-present" ]; then v=${v}d; fi;
++
++# non-existent device
++if [ -f "(00000000-0000-0000-0000-000000000003)/present" ]; then v=${v}e; fi;
++
++menuentry $v {
++	linux /vmlinux
++}
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_device *dev1, *dev2;
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++
++	ctx = test->ctx;
++
++	/* set local uuid */
++	dev1 = test->ctx->device;
++	dev1->uuid = "00000000-0000-0000-0000-000000000001";
++
++	dev2 = test_create_device(test, "extdev");
++	dev2->uuid = "00000000-0000-0000-0000-000000000002";
++	device_handler_add_device(ctx->handler, dev2);
++
++	test_add_file_data(test, dev1, "/1-present", "x", 1);
++	test_add_file_data(test, dev2, "/2-present", "x", 1);
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 1);
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "acd");
++}
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-17-discover-grub2-Add-a-reference-from-script-to-parser.patch
+++ b/openpower/package/petitboot/petitboot-17-discover-grub2-Add-a-reference-from-script-to-parser.patch
@@ -1,0 +1,43 @@
+From 3c6c55e19bae192a030f07ba0f08535c9751ac39 Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Thu, 14 Nov 2019 09:14:53 +0800
+Subject: [PATCH 18/23] discover/grub2: Add a reference from script to parser
+
+Future commands will need to access the parser, so add a reference from
+struct grub2_script.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit a9a9d575cdab5c32fcb374edf60f0e51f9f7ec9f)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/grub2.h  | 1 +
+ discover/grub2/script.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index eabd6d6..323b461 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -91,6 +91,7 @@ struct grub2_statement_for {
+ };
+ 
+ struct grub2_script {
++	struct grub2_parser		*parser;
+ 	struct grub2_statements		*statements;
+ 	struct list			environment;
+ 	struct list			symtab;
+diff --git a/discover/grub2/script.c b/discover/grub2/script.c
+index 1a802b9..f5d7d4f 100644
+--- a/discover/grub2/script.c
++++ b/discover/grub2/script.c
+@@ -510,6 +510,7 @@ struct grub2_script *create_script(struct grub2_parser *parser,
+ 	script = talloc_zero(parser, struct grub2_script);
+ 
+ 	script->ctx = ctx;
++	script->parser = parser;
+ 
+ 	list_init(&script->symtab);
+ 	list_init(&script->options);
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-18-discover-grub2-expose-internal-parse-function.patch
+++ b/openpower/package/petitboot/petitboot-18-discover-grub2-expose-internal-parse-function.patch
@@ -1,0 +1,96 @@
+From 67801ee8d7c3af2a5d75b882ad35eb966bf5d39b Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Thu, 14 Nov 2019 13:17:16 +0800
+Subject: [PATCH 19/23] discover/grub2: expose internal parse function
+
+Upcoming changes will need a method to parse a secondary file (to
+support the 'source' command), but not execute it as a new script.
+
+This change exposes the parsing code, separate from the execution code.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 2c132ebc93a44b7550b1fdb3f5f7b010e51f47e8)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/grub2-parser.y | 17 +++++++++++++++--
+ discover/grub2/grub2.c        |  2 +-
+ discover/grub2/grub2.h        |  8 ++++++--
+ 3 files changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/discover/grub2/grub2-parser.y b/discover/grub2/grub2-parser.y
+index 527a61c..f99bbfd 100644
+--- a/discover/grub2/grub2-parser.y
++++ b/discover/grub2/grub2-parser.y
+@@ -331,14 +331,15 @@ struct grub2_parser *grub2_parser_create(struct discover_context *ctx)
+ 	return parser;
+ }
+ 
+-void grub2_parser_parse(struct grub2_parser *parser, const char *filename,
++/* performs a parse on buf, setting parser->script->statements */
++int grub2_parser_parse(struct grub2_parser *parser, const char *filename,
+ 		char *buf, int len)
+ {
+ 	YY_BUFFER_STATE bufstate;
+ 	int rc;
+ 
+ 	if (!len)
+-		return;
++		return -1;
+ 
+ 	parser->script->filename = filename;
+ 
+@@ -349,6 +350,18 @@ void grub2_parser_parse(struct grub2_parser *parser, const char *filename,
+ 
+ 	yy_delete_buffer(bufstate, parser->scanner);
+ 
++	parser->inter_word = false;
++
++	return rc;
++}
++
++void grub2_parser_parse_and_execute(struct grub2_parser *parser,
++		const char *filename, char *buf, int len)
++{
++	int rc;
++
++	rc = grub2_parser_parse(parser, filename, buf, len);
++
+ 	if (!rc)
+ 		script_execute(parser->script);
+ }
+diff --git a/discover/grub2/grub2.c b/discover/grub2/grub2.c
+index a8d115f..b176ce2 100644
+--- a/discover/grub2/grub2.c
++++ b/discover/grub2/grub2.c
+@@ -169,7 +169,7 @@ static int grub2_parse(struct discover_context *dc)
+ 			continue;
+ 
+ 		parser = grub2_parser_create(dc);
+-		grub2_parser_parse(parser, *filename, buf, len);
++		grub2_parser_parse_and_execute(parser, *filename, buf, len);
+ 		device_handler_status_dev_info(dc->handler, dc->device,
+ 				_("Parsed GRUB configuration from %s"),
+ 				*filename);
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index 323b461..668d070 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -204,9 +204,13 @@ struct grub2_file *grub2_parse_file(struct grub2_script *script,
+ struct discover_device *grub2_lookup_device(struct device_handler *handler,
+ 		const char *desc);
+ 
++/* internal parse api */
++int grub2_parser_parse(struct grub2_parser *parser, const char *filename,
++		char *buf, int len);
++
+ /* external parser api */
+ struct grub2_parser *grub2_parser_create(struct discover_context *ctx);
+-void grub2_parser_parse(struct grub2_parser *parser, const char *filename,
+-		char *buf, int len);
++void grub2_parser_parse_and_execute(struct grub2_parser *parser,
++		const char *filename, char *buf, int len);
+ #endif /* GRUB2_H */
+ 
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-19-discover-grub2-make-statements_execute-non-static.patch
+++ b/openpower/package/petitboot/petitboot-19-discover-grub2-make-statements_execute-non-static.patch
@@ -1,0 +1,46 @@
+From f5d581b25c3dda2485725912e1d96da1ca520719 Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Thu, 14 Nov 2019 13:52:57 +0800
+Subject: [PATCH 20/23] discover/grub2: make statements_execute non-static
+
+We want to execute newly-parsed statements, so expose
+statements_execute() to the rest of the grub2 parser code.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 9711179694bb0e52c5951dc7222f1f79fcba814d)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/grub2.h  | 3 +++
+ discover/grub2/script.c | 2 +-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index 668d070..deaf976 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -165,6 +165,9 @@ void word_append(struct grub2_word *w1, struct grub2_word *w2);
+ /* script interface */
+ void script_execute(struct grub2_script *script);
+ 
++int statements_execute(struct grub2_script *script,
++		struct grub2_statements *stmts);
++
+ int statement_simple_execute(struct grub2_script *script,
+ 		struct grub2_statement *statement);
+ int statement_block_execute(struct grub2_script *script,
+diff --git a/discover/grub2/script.c b/discover/grub2/script.c
+index f5d7d4f..8c33f84 100644
+--- a/discover/grub2/script.c
++++ b/discover/grub2/script.c
+@@ -231,7 +231,7 @@ static void process_expansions(struct grub2_script *script,
+ 		argv->argc--;
+ }
+ 
+-static int statements_execute(struct grub2_script *script,
++int statements_execute(struct grub2_script *script,
+ 		struct grub2_statements *stmts)
+ {
+ 	struct grub2_statement *stmt;
+-- 
+2.17.1
+

--- a/openpower/package/petitboot/petitboot-20-discover-grub2-implement-source-command.patch
+++ b/openpower/package/petitboot/petitboot-20-discover-grub2-implement-source-command.patch
@@ -1,0 +1,352 @@
+From aad093d5e9ece8beb9ee86c48d727e63dccebdf7 Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Thu, 14 Nov 2019 15:06:26 +0800
+Subject: [PATCH 21/23] discover/grub2: implement 'source' command
+
+This change add support for the grub2 'source' command, executing a
+referenced script in the current parse context.
+
+We impose a limit of 10 (concurrent) source commands, to prevent
+infinite recursion.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+(cherry picked from commit 967cfa7e5c1bfb4d2cf78bb3de3dc6d36b78c440)
+Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>
+---
+ discover/grub2/builtins.c                     | 51 +++++++++++++++-
+ discover/grub2/grub2.h                        |  1 +
+ test/parser/Makefile.am                       |  4 ++
+ test/parser/test-grub2-source-functions.c     | 46 +++++++++++++++
+ .../test-grub2-source-recursion-infinite.c    | 43 ++++++++++++++
+ test/parser/test-grub2-source-recursion.c     | 58 +++++++++++++++++++
+ test/parser/test-grub2-source.c               | 54 +++++++++++++++++
+ 7 files changed, 256 insertions(+), 1 deletion(-)
+ create mode 100644 test/parser/test-grub2-source-functions.c
+ create mode 100644 test/parser/test-grub2-source-recursion-infinite.c
+ create mode 100644 test/parser/test-grub2-source-recursion.c
+ create mode 100644 test/parser/test-grub2-source.c
+
+diff --git a/discover/grub2/builtins.c b/discover/grub2/builtins.c
+index aab11ac..fd8915f 100644
+--- a/discover/grub2/builtins.c
++++ b/discover/grub2/builtins.c
+@@ -401,6 +401,51 @@ static int builtin_test(struct grub2_script *script,
+ 	return rc ? 0 : 1;
+ }
+ 
++static int builtin_source(struct grub2_script *script,
++		void *data __attribute__((unused)),
++		int argc, char *argv[])
++{
++	struct grub2_statements *statements;
++	struct discover_device *dev;
++	const char *filename;
++	char *path, *buf;
++	int rc, len;
++
++	if (argc != 2)
++		return false;
++
++	/* limit script recursion */
++	if (script->include_depth >= 10)
++		return false;
++
++	rc = parse_to_device_path(script, argv[1], &dev, &path);
++	if (rc)
++		return false;
++
++	rc = parser_request_file(script->ctx, dev, path, &buf, &len);
++	if (rc)
++		return false;
++
++	/* save current script state */
++	statements = script->statements;
++	filename = script->filename;
++	script->include_depth++;
++
++	rc = grub2_parser_parse(script->parser, argv[1], buf, len);
++
++	if (!rc)
++		statements_execute(script, script->statements);
++
++	talloc_free(script->statements);
++
++	/* restore state */
++	script->statements = statements;
++	script->filename = filename;
++	script->include_depth--;
++
++	return !rc;
++}
++
+ static int builtin_true(struct grub2_script *script __attribute__((unused)),
+ 		void *data __attribute__((unused)),
+ 		int argc __attribute__((unused)),
+@@ -487,7 +532,11 @@ static struct {
+ 	{
+ 		.name = "blscfg",
+ 		.fn = builtin_blscfg,
+-	}
++	},
++	{
++		.name = "source",
++		.fn = builtin_source,
++	},
+ };
+ 
+ static const char *nops[] = {
+diff --git a/discover/grub2/grub2.h b/discover/grub2/grub2.h
+index deaf976..75f6aa0 100644
+--- a/discover/grub2/grub2.h
++++ b/discover/grub2/grub2.h
+@@ -100,6 +100,7 @@ struct grub2_script {
+ 	const char			*filename;
+ 	unsigned int			n_options;
+ 	struct list			options;
++	int				include_depth;
+ };
+ 
+ struct grub2_parser {
+diff --git a/test/parser/Makefile.am b/test/parser/Makefile.am
+index 1631d76..5048079 100644
+--- a/test/parser/Makefile.am
++++ b/test/parser/Makefile.am
+@@ -44,6 +44,10 @@ parser_TESTS = \
+ 	test/parser/test-grub2-lexer-error \
+ 	test/parser/test-grub2-parser-error \
+ 	test/parser/test-grub2-test-file-ops \
++	test/parser/test-grub2-source \
++	test/parser/test-grub2-source-functions \
++	test/parser/test-grub2-source-recursion \
++	test/parser/test-grub2-source-recursion-infinite \
+ 	test/parser/test-grub2-single-yocto \
+ 	test/parser/test-grub2-blscfg-default-filename \
+ 	test/parser/test-grub2-blscfg-default-index \
+diff --git a/test/parser/test-grub2-source-functions.c b/test/parser/test-grub2-source-functions.c
+new file mode 100644
+index 0000000..a9da934
+--- /dev/null
++++ b/test/parser/test-grub2-source-functions.c
+@@ -0,0 +1,46 @@
++
++/* check that we can source other scripts, and functions can be defined
++ * and called across sourced scripts */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++function f1 {
++	menuentry "f1$1" { linux $2 }
++}
++
++source /grub/2.cfg
++
++f2 a /vmlinux
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++	struct discover_device *dev;
++
++	ctx = test->ctx;
++	dev = ctx->device;
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_add_file_string(test, dev,
++			"/grub/2.cfg",
++			"function f2 { menuentry \"f2$1\" { linux $2 } }\n"
++			"f1 a /vmlinux\n");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 2);
++
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "f1a");
++	check_resolved_local_resource(opt->boot_image, dev, "/vmlinux");
++
++	opt = get_boot_option(ctx, 1);
++	check_name(opt, "f2a");
++	check_resolved_local_resource(opt->boot_image, dev, "/vmlinux");
++}
+diff --git a/test/parser/test-grub2-source-recursion-infinite.c b/test/parser/test-grub2-source-recursion-infinite.c
+new file mode 100644
+index 0000000..fbcc5a3
+--- /dev/null
++++ b/test/parser/test-grub2-source-recursion-infinite.c
+@@ -0,0 +1,43 @@
++
++/* check that have a maximum source recursion limit */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++name=a$name
++
++menuentry $name {
++	linux /a
++}
++
++source /grub/grub.cfg
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++	struct discover_device *dev;
++
++	ctx = test->ctx;
++	dev = ctx->device;
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_run_parser(test, "grub2");
++
++	/* we error out after 10 levels, but we should still have
++	 * parse results up to that point
++	 */
++	check_boot_option_count(ctx, 11);
++
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "a");
++	check_resolved_local_resource(opt->boot_image, dev, "/a");
++
++	opt = get_boot_option(ctx,10);
++	check_name(opt, "aaaaaaaaaaa");
++	check_resolved_local_resource(opt->boot_image, dev, "/a");
++}
+diff --git a/test/parser/test-grub2-source-recursion.c b/test/parser/test-grub2-source-recursion.c
+new file mode 100644
+index 0000000..21b6bd2
+--- /dev/null
++++ b/test/parser/test-grub2-source-recursion.c
+@@ -0,0 +1,58 @@
++/* check that we can source other files recursively */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++menuentry a {
++	linux /a
++}
++
++source /grub/2.cfg
++
++menuentry c {
++	linux /c
++}
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++	struct discover_device *dev;
++
++	ctx = test->ctx;
++	dev = ctx->device;
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	/* four levels of config files, the last defining a boot option */
++	test_add_file_string(test, dev,
++			"/grub/2.cfg",
++			"source /grub/3.cfg\n");
++
++	test_add_file_string(test, dev,
++			"/grub/3.cfg",
++			"source /grub/4.cfg\n");
++
++	test_add_file_string(test, dev,
++			"/grub/4.cfg",
++			"menuentry b { linux /b }\n");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 3);
++
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "a");
++	check_resolved_local_resource(opt->boot_image, dev, "/a");
++
++	opt = get_boot_option(ctx, 1);
++	check_name(opt, "b");
++	check_resolved_local_resource(opt->boot_image, dev, "/b");
++
++	opt = get_boot_option(ctx, 2);
++	check_name(opt, "c");
++	check_resolved_local_resource(opt->boot_image, dev, "/c");
++}
+diff --git a/test/parser/test-grub2-source.c b/test/parser/test-grub2-source.c
+new file mode 100644
+index 0000000..a14bef7
+--- /dev/null
++++ b/test/parser/test-grub2-source.c
+@@ -0,0 +1,54 @@
++
++/* check that we can source other scripts, and variables get passed
++ * in to and out of sourced scripts */
++
++#include "parser-test.h"
++
++#if 0 /* PARSER_EMBEDDED_CONFIG */
++
++menuentry a {
++	linux /a
++}
++
++# var: outer -> inner -> outer
++v=b
++
++source /grub/2.cfg
++
++menuentry $v {
++	linux /c
++}
++
++#endif
++
++void run_test(struct parser_test *test)
++{
++	struct discover_boot_option *opt;
++	struct discover_context *ctx;
++	struct discover_device *dev;
++
++	ctx = test->ctx;
++	dev = ctx->device;
++
++	test_read_conf_embedded(test, "/grub/grub.cfg");
++
++	test_add_file_string(test, dev,
++			"/grub/2.cfg",
++			"menuentry $v { linux /b }\nv=c\n");
++
++	test_run_parser(test, "grub2");
++
++	check_boot_option_count(ctx, 3);
++
++	opt = get_boot_option(ctx, 0);
++	check_name(opt, "a");
++	check_resolved_local_resource(opt->boot_image, dev, "/a");
++
++	opt = get_boot_option(ctx, 1);
++	check_name(opt, "b");
++	check_resolved_local_resource(opt->boot_image, dev, "/b");
++
++	opt = get_boot_option(ctx, 2);
++	check_name(opt, "c");
++	check_resolved_local_resource(opt->boot_image, dev, "/c");
++}
+-- 
+2.17.1
+


### PR DESCRIPTION
Fixes to Petitboot so we can support a few more grub2 syntaxes:

 - 'search --label' support
 -  (device)/path style file references
 - `source` command support

These are required to support some OpenShift installations

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>