### PR TITLE
petitboot: Update to v1.12

### DIFF
--- a/openpower/package/petitboot/petitboot.hash
+++ b/openpower/package/petitboot/petitboot.hash
@@ -1,1 +1,1 @@
-sha256 b680747297e17ea1e730d5eacfe09f53f9b1e02d89dfea2fd5766c4b07415cdb  petitboot-v1.11.tar.gz
+sha256 121cab15b1eaaccbe9e054ee1af79d379dc4576379c2c09eb69ccad3ffd7bc5d  petitboot-v1.12.tar.gz

--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PETITBOOT_VERSION = v1.11
+PETITBOOT_VERSION = v1.12
 PETITBOOT_SOURCE = petitboot-$(PETITBOOT_VERSION).tar.gz
 PETITBOOT_SITE ?= https://github.com/open-power/petitboot/releases/download/$(PETITBOOT_VERSION)
 PETITBOOT_DEPENDENCIES = ncurses udev host-bison host-flex lvm2


### PR DESCRIPTION
This change bumps us up to petitboot v1.12, which contains a pre-boot
check feature for ultravisor enabled kernels, support for kexec file,
and the display of secure and trusted boot state.

Jeremy Kerr (10):
      lib/pb-protocol: fix ordering of system info length calculation
      lib/types: consolidate struct system_info layout with serialised version
      protocol,types: Add secure & trusted boot state to system info
      discover/powerpc: detect secureboot enforcing mode
      ui/ncurses: Add secure & trusted boot status
      discover/boot: add support for `kexec -s` for kexec_file_load
      discover/boot: unify verification failure messages
      Remove unused 's' file
      docker: build petitboot outside of the source dir
      test/parser: Add rhel8 test data to check_DATA

Maxiwell S. Garcia (4):
      configure: Add libelf as a requirement
      discover: Add helper functions to read ELF notes
      ui/ncurses: Add preboot check option in the config screen
      discover: Check if the kernel image has Ultravisor support

Signed-off-by: Joel Stanley <joel@jms.id.au>