### PR TITLE
libflash.mk: fix version and add dependencies

### DIFF
--- a/openpower/package/libflash/libflash.mk
+++ b/openpower/package/libflash/libflash.mk
@@ -4,16 +4,18 @@
 #
 ################################################################################
 
+LIBFLASH_VERSION = $(call qstrip,$(BR2_SKIBOOT_VERSION))
+
 ifeq ($(BR2_SKIBOOT_CUSTOM_GIT),y)
 LIBFLASH_SITE = $(call qstrip,$(BR2_SKIBOOT_CUSTOM_REPO_URL))
 LIBFLASH_SITE_METHOD = git
 else
-LIBFLASH_VERSION = $(call qstrip,$(BR2_SKIBOOT_VERSION))
 LIBFLASH_SITE = $(call github,open-power,skiboot,$(LIBFLASH_VERSION))
 endif
 
 LIBFLASH_INSTALL_STAGING = YES
 LIBFLASH_INSTALL_TARGET = YES
+LIBFLASH_DEPENDENCIES += skiboot
 
 LIBFLASH_LICENSE_FILES = LICENCE
 


### PR DESCRIPTION
LIBFLASH_VERSION is not set correctly when using a
BR2_SKIBOOT_CUSTOM_GIT, causing the package to
not be downloaded.

Additionally, add skiboot as a build-time dependency

Supersedes #3451