### PR TITLE
openpower-pnor.mk: Use correct kernel version macro

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -75,9 +75,9 @@ GENERATED_PNOR_LAYOUT_FILES = $(shell find "$(OPENPOWER_PNOR_SCRATCH_DIR)" -maxd
 FILES_TO_TAR = $(HOSTBOOT_BUILD_IMAGES_DIR)/* \
                $(OUTPUT_BUILD_DIR)/skiboot-$(BR2_SKIBOOT_VERSION)/skiboot.elf \
                $(OUTPUT_BUILD_DIR)/skiboot-$(BR2_SKIBOOT_VERSION)/skiboot.map \
-               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE)/.config \
-               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE)/vmlinux \
-               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE)/System.map \
+               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_VERSION)/.config \
+               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_VERSION)/vmlinux \
+               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_VERSION)/System.map \
                $(OUTPUT_IMAGES_DIR)/zImage.epapr \
                $(GENERATED_PNOR_LAYOUT_FILES)
 


### PR DESCRIPTION
BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE is not always defined (i.e., when
using a Custom Repo, Latest version etc). However,
BR2_LINUX_KERNEL_VERSION will always default to whatever kernel version
we are using.

This fixes building openpower-pnor when not using a Kernel Custom
version.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>