### PR TITLE
Update Petitboot to 1.7.6

### DIFF
--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PETITBOOT_VERSION = v1.7.5
+PETITBOOT_VERSION = v1.7.6
 PETITBOOT_SITE ?= $(call github,open-power,petitboot,$(PETITBOOT_VERSION))
 PETITBOOT_DEPENDENCIES = ncurses udev host-bison host-flex lvm2
 PETITBOOT_LICENSE = GPLv2


### PR DESCRIPTION
Petitboot 1.7.6 contains significant fixes versus 1.7.5, most notably in
the area of grub2 config parsing that some Distros are now using. This
update should prevent Petitboot from trapping or not finding
configurations on Red Hat Enterprise Linux and OpenShift installations.

Update summary:

----------------------------------------------------------------
Brandon Bergren (1):
      Fix pb-discover segfaults caused by list corruption.

Brett Grandbois (3):
      discover/grub: Add cmdline signature support for BLS entries
      lib/file: remove mkstemp umask in copy_file_secure_dest
      discover/boot: abort kexec on any error from validation

Geoff Levand (1):
      lib/talloc: Fix TALLOC_ABORT

Javier Martinez Canillas (10):
      discover/grub: Add blscfg command support to parse BootLoaderSpec files
      discover/grub: Allow to choose a different BLS directory
      discover/grub: Reverse BLS entries sorting to match Petitboot's boot order
      discover/grub: Don't add discover context boot options in blscfg handler
      discover/grub: Allow to set a default index for BLS entries
      test/parser: Make parser_scandir() ignore files with path len less than dir
      discover/grub: Use different paths to search for the BLS directory
      discover/grub: Improve BLS grub environment variables expansion
      discover/grub2: Allow using title for default even if id was defined
      discover/grub2: Allow to separate the --id argument using a space char

Jeremy Kerr (14):
      discover/grub2: 'search' set-variable defaults to root
      discover/grub2: Use getopt for `search` argument parsing
      discover/grub2: test for (ignored) --no-floppy argument
      discover/grub2: Add support for UUID and label for 'search' command
      discover/grub2: expose a struct for grub2 file references
      discover/grub2: Add parsing code for grub2 file specifiers
      discover/grub2: add support for grub2-style path specifiers in resources
      discover/grub2: Allow (device)/path references in general script usage
      discover/grub2: Add a reference from script to parser
      discover/grub2: expose internal parse function
      discover/grub2: make statements_execute non-static
      discover/grub2: implement 'source' command
      test/parser: Add test for recent RHCOS grub2 config
      test/parser: Add RHEL8 grub config test

Klaus Heinrich Kiwi (1):
      travis: update dist from trusty to bionic

Samuel Mendoza-Jonas (10):
      discover/pxe-parser: Avoid potential null dereference
      lib/file: Avoid off-by-one error in array
      lib/security: Fix broken if statements in gpg_validate_boot_files()
      discover: Rescan SCSI devices on reinit
      discover/udev: Don't require ID_NET_NAME_PATH property
      discover/user-event: Check for required parameters
      discover/boot: Fix talloc parent for resource URLs
      discover: Display warning if saving config fails
      utils/pb-console: Ignore SIGINT
      utils: Quote plugin name and vendor variables

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>