### PR TITLE
openpower-pnor.mk: use correct version vars

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -73,11 +73,11 @@ HOSTBOOT_BUILD_IMAGES_DIR = $(STAGING_DIR)/hostboot_build_images/
 GENERATED_PNOR_LAYOUT_FILES = $(shell find "$(OPENPOWER_PNOR_SCRATCH_DIR)" -maxdepth 1 -name "*WithOffsets.xml")
 
 FILES_TO_TAR = $(HOSTBOOT_BUILD_IMAGES_DIR)/* \
-               $(OUTPUT_BUILD_DIR)/skiboot-$(BR2_SKIBOOT_VERSION)/skiboot.elf \
-               $(OUTPUT_BUILD_DIR)/skiboot-$(BR2_SKIBOOT_VERSION)/skiboot.map \
-               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_VERSION)/.config \
-               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_VERSION)/vmlinux \
-               $(OUTPUT_BUILD_DIR)/linux-$(BR2_LINUX_KERNEL_VERSION)/System.map \
+               $(OUTPUT_BUILD_DIR)/skiboot-$(SKIBOOT_VERSION)/skiboot.elf \
+               $(OUTPUT_BUILD_DIR)/skiboot-$(SKIBOOT_VERSION)/skiboot.map \
+               $(OUTPUT_BUILD_DIR)/linux-$(LINUX_VERSION)/.config \
+               $(OUTPUT_BUILD_DIR)/linux-$(LINUX_VERSION)/vmlinux \
+               $(OUTPUT_BUILD_DIR)/linux-$(LINUX_VERSION)/System.map \
                $(OUTPUT_IMAGES_DIR)/zImage.epapr \
                $(GENERATED_PNOR_LAYOUT_FILES)
 
@@ -133,7 +133,7 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -payload_filename $(BR2_SKIBOOT_LID_XZ_NAME) \
             -binary_dir $(BINARIES_DIR) \
             -bootkernel_filename $(LINUX_IMAGE_NAME) \
-	    -ocmbfw_version $(BR2_OCMB_EXPLORER_FW_VERSION) \
+	    -ocmbfw_version $(OCMB_EXPLORER_FW_VERSION) \
 	    -ocmbfw_url $(BR2_OCMB_EXPLORER_FW_URL) \
 	    -ocmbfw_original_filename $(BINARIES_DIR)/$(BR2_OCMBFW_FILENAME) \
 	    -ocmbfw_binary_filename $(OPENPOWER_PNOR_SCRATCH_DIR)/$(BR2_OCMBFW_PROCESSED_FILENAME) \


### PR DESCRIPTION
Use the correct <pkg>_VERSION variables for packages, instead of the
ones defined in _defconfig.

Fixes build in situations where the <pkg>_VERSION variable is overriden
(i.e., when using <pkg>_OVERRIDE_SRCDIR) since the build directory
always depends on this variable, not the one defined in the _defconfig.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>