### PR TITLE
pnor size adjustment for skiboot

### DIFF
--- a/openpower/package/openpower-pnor/0001-Increase-PAYLOAD-partition-to-1MB.patch
+++ b/openpower/package/openpower-pnor/0001-Increase-PAYLOAD-partition-to-1MB.patch
@@ -1,0 +1,191 @@
+From 605bf7f54a33441f03b9b6bd66173d6cf264554e Mon Sep 17 00:00:00 2001
+From: Eric Richter <erichte@linux.ibm.com>
+Date: Thu, 2 Apr 2020 19:17:03 -0500
+Subject: [PATCH] Increase PAYLOAD partition to 1MB
+
+---
+ p9Layouts/defaultPnorLayout_64.xml | 40 +++++++++++++++---------------
+ 1 file changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/p9Layouts/defaultPnorLayout_64.xml b/p9Layouts/defaultPnorLayout_64.xml
+index 1e74c51..978b4d9 100644
+--- a/p9Layouts/defaultPnorLayout_64.xml
++++ b/p9Layouts/defaultPnorLayout_64.xml
+@@ -213,10 +213,10 @@ Layout Description
+         <ecc/>
+     </section>
+     <section>
+-        <description>Payload (0.5MB)</description>
++        <description>Payload (1MB)</description>
+         <eyeCatch>PAYLOAD</eyeCatch>
+         <physicalOffset>0x20C1000</physicalOffset>
+-        <physicalRegionSize>0x80000</physicalRegionSize>
++        <physicalRegionSize>0x100000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+         <readOnly/>
+@@ -224,7 +224,7 @@ Layout Description
+     <section>
+         <description>Bootloader Kernel (15.5MB)</description>
+         <eyeCatch>BOOTKERNEL</eyeCatch>
+-        <physicalOffset>0x2141000</physicalOffset>
++        <physicalOffset>0x21C1000</physicalOffset>
+         <physicalRegionSize>0xF80000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -233,7 +233,7 @@ Layout Description
+     <section>
+         <description>OCC Lid (1.125M)</description>
+         <eyeCatch>OCC</eyeCatch>
+-        <physicalOffset>0x30C1000</physicalOffset>
++        <physicalOffset>0x3141000</physicalOffset>
+         <physicalRegionSize>0x120000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -243,7 +243,7 @@ Layout Description
+     <section>
+         <description>Checkstop FIR data (12K)</description>
+         <eyeCatch>FIRDATA</eyeCatch>
+-        <physicalOffset>0x31E1000</physicalOffset>
++        <physicalOffset>0x3261000</physicalOffset>
+         <physicalRegionSize>0x3000</physicalRegionSize>
+         <side>A</side>
+         <ecc/>
+@@ -253,7 +253,7 @@ Layout Description
+     <section>
+         <description>CAPP Lid (144K)</description>
+         <eyeCatch>CAPP</eyeCatch>
+-        <physicalOffset>0x31E4000</physicalOffset>
++        <physicalOffset>0x3264000</physicalOffset>
+         <physicalRegionSize>0x24000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -263,7 +263,7 @@ Layout Description
+     <section>
+         <description>BMC Inventory (36K)</description>
+         <eyeCatch>BMC_INV</eyeCatch>
+-        <physicalOffset>0x3208000</physicalOffset>
++        <physicalOffset>0x3288000</physicalOffset>
+         <physicalRegionSize>0x9000</physicalRegionSize>
+         <side>sideless</side>
+         <reprovision/>
+@@ -271,7 +271,7 @@ Layout Description
+     <section>
+         <description>Hostboot Bootloader (28K)</description>
+         <eyeCatch>HBBL</eyeCatch>
+-        <physicalOffset>0x3211000</physicalOffset>
++        <physicalOffset>0x3291000</physicalOffset>
+         <!-- Physical Size includes Header rounded to ECC valid size -->
+         <!-- Max size of actual HBBL content is 20K and 22.5K with ECC -->
+         <physicalRegionSize>0x7000</physicalRegionSize>
+@@ -283,7 +283,7 @@ Layout Description
+     <section>
+         <description>Temporary Attribute Override (32K)</description>
+         <eyeCatch>ATTR_TMP</eyeCatch>
+-        <physicalOffset>0x3218000</physicalOffset>
++        <physicalOffset>0x3298000</physicalOffset>
+         <physicalRegionSize>0x8000</physicalRegionSize>
+         <side>A</side>
+         <reprovision/>
+@@ -291,7 +291,7 @@ Layout Description
+     <section>
+         <description>Permanent Attribute Override (32K)</description>
+         <eyeCatch>ATTR_PERM</eyeCatch>
+-        <physicalOffset>0x3220000</physicalOffset>
++        <physicalOffset>0x32A0000</physicalOffset>
+         <physicalRegionSize>0x8000</physicalRegionSize>
+         <side>A</side>
+         <ecc/>
+@@ -301,7 +301,7 @@ Layout Description
+     <section>
+         <description>PNOR Version (4K)</description>
+         <eyeCatch>VERSION</eyeCatch>
+-        <physicalOffset>0x3228000</physicalOffset>
++        <physicalOffset>0x32A8000</physicalOffset>
+         <physicalRegionSize>0x2000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -310,7 +310,7 @@ Layout Description
+     <section>
+         <description>IMA Catalog (256K)</description>
+         <eyeCatch>IMA_CATALOG</eyeCatch>
+-        <physicalOffset>0x322A000</physicalOffset>
++        <physicalOffset>0x32AA000</physicalOffset>
+         <physicalRegionSize>0x40000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -320,7 +320,7 @@ Layout Description
+     <section>
+         <description>Ref Image Ring Overrides (128K)</description>
+         <eyeCatch>RINGOVD</eyeCatch>
+-        <physicalOffset>0x326A000</physicalOffset>
++        <physicalOffset>0x32EA000</physicalOffset>
+         <physicalRegionSize>0x20000</physicalRegionSize>
+         <side>A</side>
+     </section>
+@@ -329,7 +329,7 @@ Layout Description
+         <!-- We need 266KB per module sort, going to support
+              10 sorts by default, plus ECC  -->
+         <eyeCatch>WOFDATA</eyeCatch>
+-        <physicalOffset>0x328A000</physicalOffset>
++        <physicalOffset>0x330A000</physicalOffset>
+         <physicalRegionSize>0x300000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -339,7 +339,7 @@ Layout Description
+     <section>
+         <description>Hostboot deconfig area (64KB)</description>
+         <eyeCatch>HB_VOLATILE</eyeCatch>
+-        <physicalOffset>0x358A000</physicalOffset>
++        <physicalOffset>0x360A000</physicalOffset>
+         <physicalRegionSize>0x5000</physicalRegionSize>
+         <side>A</side>
+         <reprovision/>
+@@ -350,7 +350,7 @@ Layout Description
+     <section>
+         <description>Memory config data (28K)</description>
+         <eyeCatch>MEMD</eyeCatch>
+-        <physicalOffset>0x358F000</physicalOffset>
++        <physicalOffset>0x360F000</physicalOffset>
+         <physicalRegionSize>0xE000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -360,7 +360,7 @@ Layout Description
+     <section>
+         <description>SecureBoot Key Transition Partition (16K)</description>
+         <eyeCatch>SBKT</eyeCatch>
+-        <physicalOffset>0x359D000</physicalOffset>
++        <physicalOffset>0x361D000</physicalOffset>
+         <physicalRegionSize>0x4000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -370,7 +370,7 @@ Layout Description
+     <section>
+         <description>HDAT binary data (32KB)</description>
+         <eyeCatch>HDAT</eyeCatch>
+-        <physicalOffset>0x35A1000</physicalOffset>
++        <physicalOffset>0x3621000</physicalOffset>
+         <physicalRegionSize>0x8000</physicalRegionSize>
+         <side>sideless</side>
+         <sha512Version/>
+@@ -380,7 +380,7 @@ Layout Description
+     <section>
+         <description>Ultravisor binary image (1MB)</description>
+         <eyeCatch>UVISOR</eyeCatch>
+-        <physicalOffset>0x35A9000</physicalOffset>
++        <physicalOffset>0x3629000</physicalOffset>
+         <physicalRegionSize>0x100000</physicalRegionSize>
+         <side>sideless</side>
+         <sha512Version/>
+@@ -389,7 +389,7 @@ Layout Description
+     <section>
+         <description>Hostboot Runtime Proxy (32KB)</description>
+         <eyeCatch>HBRT_PROXY</eyeCatch>
+-        <physicalOffset>0x36A9000</physicalOffset>
++        <physicalOffset>0x3729000</physicalOffset>
+         <physicalRegionSize>0x8000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+-- 
+2.26.0
+


### PR DESCRIPTION
After adding new TSS and crypto library (mbedtls) packages,
the size of skiboot is almost closed to 500MB. This can very
soon be an issue if any new functionality is added.

Signed-off-by: Eric Richter <erichte@linux.ibm.com>
Signed-off-by: Nayna Jain <nayna@linux.ibm.com>