### PR TITLE
Fixes package list for Ubuntu 20.04 CI

### DIFF
--- a/ci/Dockerfile/ubuntu2004
+++ b/ci/Dockerfile/ubuntu2004
@@ -2,9 +2,9 @@ FROM ubuntu:20.04
 # Don't ask. Ubuntu is awful.
 RUN sed -e 's/main$/main universe/' --in-place=orig /etc/apt/sources.list
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yy cscope ctags libz-dev libexpat-dev \
-          python language-pack-en texinfo gawk cpio xxd \
+          python-is-python3 language-pack-en texinfo gawk cpio xxd \
           build-essential g++ git bison flex unzip \
           libssl-dev libxml-simple-perl libxml-sax-perl libxml-parser-perl libxml2-dev libxml2-utils xsltproc \
           wget bc rsync
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install eatmydata python-matplotlib \
-          python-numpy graphviz bsdmainutils lsb-release
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install eatmydata python3-matplotlib \
+          python3-scipy graphviz bsdmainutils lsb-release


### PR DESCRIPTION
Commit 34b9a2dc7 moved the CI to Ubuntu 20.04 Focal but was
still depending on python-matplotlib and python-numpy for it's
'release' steps (where make legal-info and graphs are built),
while those are no longer available in Focal.

Replace them for python3-matplotlib and python3-scipy, also
adjusting python to python3-is-python so that things work
again.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.bnet.ibm.com>
----------
I missed this since the Ci was skipping silently for Ubuntu 20.04 containers. That should be fixed as well.

Fixes #3808