### PR TITLE
Add perl dependencies for building on Fedora 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ a handful of other packages (see below).
           zlib-devel zlib-static texinfo "perl(bigint)" "perl(XML::Simple)" \
           "perl(YAML)" "perl(XML::SAX)" "perl(Fatal)" "perl(Thread::Queue)" \
           "perl(Env)" "perl(XML::LibXML)" "perl(Digest::SHA1)" "perl(ExtUtils::MakeMaker)" \
+          "perl(FindBin)" "perl(English)" "perl(Time::localtime)" \
           libxml2-devel which wget unzip tar cpio python bzip2 bc findutils ncurses-devel \
           openssl-devel make libxslt vim-common lzo-devel python2 rsync hostname
 


### PR DESCRIPTION
Add perl FindBin, English, Time dependencies for Fedora
    
Otherwise host-libopenssl fails to build, saying ppc64el isn't
supported, but a couple of lines up, hints at the perl module.
    
Hostboot also needs the English and Time::localtime modules.

This should also be cherry-picked to v2.6 at least.