### PR TITLE
Moving ocmb-explorer-fw up to newest Explorer release.

### DIFF
--- a/openpower/package/ocmb-explorer-fw/Config.in
+++ b/openpower/package/ocmb-explorer-fw/Config.in
@@ -8,14 +8,14 @@ if BR2_PACKAGE_OCMB_EXPLORER_FW
 
 config BR2_OCMB_EXPLORER_FW_VERSION
 	string
-	default "v7.0"
+	default "CL419357"
 
 config BR2_OCMB_EXPLORER_FW_SITE
         string
-        default "https://github.com/open-power/ocmb-explorer-fw/files/5097185"
+        default "https://github.com/open-power/ocmb-explorer-fw/files/5823431"
 
 config BR2_OCMB_EXPLORER_FW_SOURCE
         string
-        default "FW397559BinaryOnly.zip"
+        default "FW419357BinaryOnly.zip"
 
 endif


### PR DESCRIPTION
Move to CL419357 release

Signed-off-by: Dan Crowell dcrowell@us.ibm.com