### PR TITLE
ci: Add Fedora33 to default CONTAINERS being built

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ a handful of other packages (see below).
           zlib-devel zlib-static texinfo "perl(bigint)" "perl(XML::Simple)" \
           "perl(YAML)" "perl(XML::SAX)" "perl(Fatal)" "perl(Thread::Queue)" \
           "perl(Env)" "perl(XML::LibXML)" "perl(Digest::SHA1)" "perl(ExtUtils::MakeMaker)" \
-          "perl(FindBin)" "perl(English)" "perl(Time::localtime)" \
+          "perl(FindBin)" "perl(English)" "perl(Time::localtime)" "perl(open)" \
           libxml2-devel which wget unzip tar cpio python bzip2 bc findutils ncurses-devel \
-          openssl-devel make libxslt vim-common lzo-devel python2 rsync hostname
+          openssl-devel make libxslt vim-common lzo-devel python2 rsync hostname diffutils
 

--- a/ci/Dockerfile/fedora33
+++ b/ci/Dockerfile/fedora33
@@ -3,6 +3,7 @@ RUN dnf -y install gcc-c++ flex bison git ctags cscope expat-devel patch \
           zlib-devel zlib-static texinfo "perl(bigint)" "perl(XML::Simple)" \
           "perl(YAML)" "perl(XML::SAX)" "perl(Fatal)" "perl(Thread::Queue)" \
           "perl(Env)" "perl(XML::LibXML)" "perl(Digest::SHA1)" "perl(ExtUtils::MakeMaker)" \
+          "perl(FindBin)" "perl(English)" "perl(Time::localtime)" "perl(open)" \
           libxml2-devel which wget unzip tar cpio python bzip2 bc findutils ncurses-devel \
-          openssl-devel make libxslt vim-common lzo-devel python2 rsync hostname
+          openssl-devel make libxslt vim-common lzo-devel python2 rsync hostname diffutils
 RUN dnf -y install nosync redhat-lsb-core python-matplotlib python-numpy graphviz

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,7 +3,7 @@
 set -ex
 set -eo pipefail
 
-CONTAINERS="ubuntu2004 fedora32"
+CONTAINERS="ubuntu2004 fedora33"
 SDK_ONLY=0
 
 opt=$(getopt -o 's:Sab:p:c:hr' -- "$@")


### PR DESCRIPTION
Commit 23a11fb "ci: Move Fedora32 Dockerfile to Fedora33" moved the CI
build script to use Fedora33, but this was actually not the default in
the main build.sh script when no Distros were being specified.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>