### PR TITLE
Set config flag for Hostboot to use PLDM for PNOR file-io operations

### DIFF
--- a/openpower/configs/hostboot/p10ebmc.config
+++ b/openpower/configs/hostboot/p10ebmc.config
@@ -1,7 +1,9 @@
-# The HIOMAP protocol is used to access PNOR
+# PLDM is used to access PNOR
+set FILE_XFER_VIA_PLDM
+
 unset SFC_IS_AST2500
 unset SFC_IS_AST2400
-set   PNORDD_IS_IPMI
+unset PNORDD_IS_IPMI
 unset PNORDD_IS_SFC
 unset ALLOW_MICRON_PNOR
 unset ALLOW_MACRONIX_PNOR


### PR DESCRIPTION
Set FILE_XFER_VIA_PLDM and unset PNORDD_IS_IPMI in the hostboot's
configuration file p10ebmc.config to start using PLDM commands to
read and write the lids on the BMC that contain PNOR data.

RTC: 208802