### PR TITLE
Remove targeting_RW_binary_source Parameter

### DIFF
--- a/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
+++ b/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
@@ -83,7 +83,6 @@ define OPENPOWER_PNOR_P10_UPDATE_IMAGE
             -targeting_RO_binary_filename $(TARGETING_BINARY_FILENAME).protected \
             -targeting_RO_binary_source $(TARGETING_BINARY_SOURCE).protected \
             -targeting_RW_binary_filename $(TARGETING_BINARY_FILENAME).unprotected \
-            -targeting_RW_binary_source $(TARGETING_BINARY_SOURCE).unprotected \
             -sbe_binary_filename $(BR2_HOSTBOOT_P10_BINARY_SBE_FILENAME) \
             -sbe_binary_dir $(STAGING_DIR)/sbe_binaries \
             -sbec_binary_filename $(BR2_HOSTBOOT_P10_BINARY_SBEC_FILENAME) \

--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -117,7 +117,6 @@ define OPENPOWER_PNOR_INSTALL_IMAGES_CMDS
             -targeting_RO_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME).protected \
             -targeting_RO_binary_source $(BR2_OPENPOWER_TARGETING_BIN_FILENAME).protected \
             -targeting_RW_binary_filename $(BR2_OPENPOWER_TARGETING_ECC_FILENAME).unprotected \
-            -targeting_RW_binary_source $(BR2_OPENPOWER_TARGETING_BIN_FILENAME).unprotected \
             -sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME) \
             -sbe_binary_dir $(SBE_BINARY_DIR) \
             -sbec_binary_filename $(BR2_HOSTBOOT_BINARY_SBEC_FILENAME) \


### PR DESCRIPTION
This commit removes the targeting_RW_binary_source parameter from
update_image.pl, since the parameter is no longer used.

Signed-off-by: Ilya Smirnov <ismirno@us.ibm.com>