### PR TITLE
Adding files hbicore.syms and hbotStringFile to the PNOR scratch dir

### DIFF
--- a/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
+++ b/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
@@ -146,6 +146,8 @@ define OPENPOWER_PNOR_P10_UPDATE_IMAGE
             PATH=$(HOST_DIR)/usr/sbin:$(PATH) $(HOST_DIR)/usr/bin/generate-ubi \
                 $(XML_VAR).pnor.squashfs.tar ;\
             $(INSTALL) $(STAGING_DIR)/pnor.$(XML_VAR)/$(XML_VAR).pnor.ubi.mtd $(BINARIES_DIR) ;\
+            $(INSTALL) -m 0644 -D $(STAGING_DIR)/hostboot_build_images/hbicore.syms $(PNOR_SCRATCH_DIR)/HBICORE_SYMS.ipllid ;\
+            $(INSTALL) -m 0644 -D $(STAGING_DIR)/hostboot_build_images/hbotStringFile $(PNOR_SCRATCH_DIR)/HBOTSTRINGFILE.ipllid ;\
             $(TARGET_MAKE_ENV) $(@D)/makelidpkg \
                 $(BINARIES_DIR)/$(XML_VAR).ebmc_lids.tar.gz \
                 $(PNOR_SCRATCH_DIR); \
@@ -163,7 +165,7 @@ define OPENPOWER_PNOR_P10_UPDATE_IMAGE
                     $(BINARIES_DIR)/$(BR2_OPENPOWER_PNOR_P10_LEGACY_PNOR_TARGET).pnor.ubi.mtd ;\
             fi ;\
         fi
-        # Copy images to mmc dir 
+        # Copy images to mmc dir
         # HBBL
         test -f "$(BINARIES_DIR)/mmc/HBBL.P10" ||\
              $(INSTALL) -m 0644 -D $(PNOR_SCRATCH_DIR)/hbbl.bin.ecc \


### PR DESCRIPTION
Adding files hbicore.syms and hbotStringFile to the PNOR scratch dir so LID files can be created from these files. hbicore.syms will be LID file 81e00686 and hbotStringFile file will be LID file 81e00685.

RTC: 295909