### PR TITLE
skiboot: Use open-opwer/skiboot.git again

### DIFF
--- a/openpower/package/skiboot/Config.in
+++ b/openpower/package/skiboot/Config.in
@@ -37,11 +37,9 @@ config BR2_SKIBOOT_VERSION
 
 config BR2_SKIBOOT_CUSTOM_GIT
 	bool "Custom git repository"
-	default y
 
 config BR2_SKIBOOT_CUSTOM_REPO_URL
 	string "URL of custom repository"
-	default "git@github.com:open-power/skiboot.git"
 	depends on BR2_SKIBOOT_CUSTOM_GIT
 
 config BR2_SKIBOOT_DEVICETREE


### PR DESCRIPTION
By defaulting to BR2_SKIBOOT_CUSTOM_GIT, the custom URL overrode the
default URL for the skiboot repo, forcing the need to have a defualt
custom URL too.

This which was used during internal p10 bring up to force the URL to an
internal repository. There's no need to do it now, and github.com is
moving away from the git:// protocol, so remove the custom default so we
get buildroot's normal URL construction from SKIBOOT_SITE in skiboot.mk.

Overriding the URL can still be done via the defconfig where it is
useful.

Signed-off-by: Joel Stanley <joel@jms.id.au>