### PR TITLE
firmware-whitelist: Ship bnx2x firmware version 7.13.15.0

### DIFF
--- a/openpower/scripts/firmware-whitelist
+++ b/openpower/scripts/firmware-whitelist
@@ -6,7 +6,7 @@
 # slash is required.
 whitelist=(     'acenic/'
                 'bnx2/'
-                'bnx2x/bnx2x-e2-7.13.11.0.fw'
+                'bnx2x/bnx2x-e2-7.13.15.0.fw'
                 'cxgb4/t4fw-1.16.63.0.bin'
                 'cxgb4/t4fw.bin'
                 'cxgb3/'


### PR DESCRIPTION
The 5.10 kernel requires a newer version of Broadcom bnx2x firmware, but
can not find it in the rootfs:

  bnx2x: [bnx2x_init_firmware:13480(enP52p1s0f0)]Can't load firmware file bnx2x/bnx2x-e2-7.13.15.0.fw

Update the firmware whitelist script to include this newer version.

Signed-off-by: Reza Arbab <arbab@linux.ibm.com>