### PR TITLE
RH8: Update the call to python to be python2 in migration effort to Red Hat 8

### DIFF
--- a/openpower/package/sbe-p10/sbe-p10.mk
+++ b/openpower/package/sbe-p10/sbe-p10.mk
@@ -30,7 +30,7 @@ endef
 
 define SBE_P10_INSTALL_IMAGES_CMDS
 	$(INSTALL) -D $(@D)/images/ipl_image_tool $(HOST_DIR)/usr/bin/
-	python $(@D)/src/build/sbeOpDistribute.py  --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
+	python2 $(@D)/src/build/sbeOpDistribute.py  --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
 	cp $(@D)/src/build/sbeOpDistribute.py $(STAGING_DIR)/sbe_binaries/
 	cp $(@D)/src/build/sbeOpToolsRegister.py $(STAGING_DIR)/sbe_binaries/
 endef


### PR DESCRIPTION
RH7 has /bin/python defined in it's environment whereas RH8 will not.  RH8
will not have a default of /bin/python but will only have /bin/python2 and
/bin/python3 defined.

Considering that for RH7 /bin/python is just a symbolic link to /bin/python2,
making this change to explicitly call python2 will have no detrimental affects
for compiling SBE on RH7 but will position the compiling of the SBE code on
RH8 for success.

Signed-off-by: Roland Veloz <rveloz@us.ibm.com>