### PR TITLE
P9: Migration effort to Red Hat 8

### DIFF
--- a/openpower/package/sbe/sbe.mk
+++ b/openpower/package/sbe/sbe.mk
@@ -22,7 +22,7 @@ endef
 
 define SBE_INSTALL_IMAGES_CMDS
 	$(INSTALL) -D $(@D)/images/p9_ipl_build  $(HOST_DIR)/usr/bin/
-	python $(@D)/src/build/sbeOpDistribute.py --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME)
+	python2 $(@D)/src/build/sbeOpDistribute.py --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BR2_HOSTBOOT_BINARY_SBE_FILENAME)
 	cp $(@D)/src/build/sbeOpDistribute.py $(STAGING_DIR)/sbe_binaries/
 endef
 


### PR DESCRIPTION
Update the call from python to python2 in migration effort to Red Hat 8.

RH7 has /bin/python defined in it's environment whereas RH8 will not. RH8
will not have a default of /bin/python but will only have /bin/python2 and
/bin/python3 defined.

Considering that for RH7, /bin/python is just a symbolic link to /bin/python2,
making this change to explicitly call python2 will have no detrimental affect.

Signed-off-by: Roland Veloz <rveloz@us.ibm.com>