### PR TITLE
Add occStringFile to PNOR scratch dir

### DIFF
--- a/openpower/package/occ-p10/occ-p10.mk
+++ b/openpower/package/occ-p10/occ-p10.mk
@@ -17,6 +17,7 @@ OCC_P10_INSTALL_TARGET = NO
 OCC_P10_STAGING_DIR = $(STAGING_DIR)/occ
 
 OCC_P10_IMAGE_BIN_PATH = obj/image.bin
+OCC_P10_STRING_PATH = obj/occStringFile
 
 OCC_P10_DEPENDENCIES = host-binutils host-ppe42-gcc
 ifeq ($(BR2_OCC_P10_GPU_BIN_BUILD),y)
@@ -38,6 +39,7 @@ OCC_P10_BUILD_CMDS ?= $(OCC_BUILD_CMDS_P9)
 define OCC_P10_INSTALL_IMAGES_CMDS
        mkdir -p $(STAGING_DIR)/occ
        cp $(@D)/$(OCC_P10_IMAGE_BIN_PATH) $(OCC_P10_STAGING_DIR)/$(BR2_OCC_P10_BIN_FILENAME)
+       cp $(@D)/$(OCC_P10_STRING_PATH)    $(OCC_P10_STAGING_DIR)/occStringFile
 endef
 
 $(eval $(generic-package))

--- a/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
+++ b/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
@@ -151,6 +151,7 @@ define OPENPOWER_PNOR_P10_UPDATE_IMAGE
             $(INSTALL) -m 0644 -D $(STAGING_DIR)/sbe_sim_data/sbeMeasurementStringFile $(PNOR_SCRATCH_DIR)/SBEMSTRINGFILE.ipllid ;\
             $(INSTALL) -m 0644 -D $(STAGING_DIR)/sbe_sim_data/sbeStringFile_DD1 $(PNOR_SCRATCH_DIR)/SBESTRINGFILE.ipllid ;\
             $(INSTALL) -m 0644 -D $(STAGING_DIR)/sbe_sim_data/sbeVerificationStringFile $(PNOR_SCRATCH_DIR)/SBEVSTRINGFILE.ipllid ;\
+            $(INSTALL) -m 0644 -D $(OCC_STAGING_DIR)/occStringFile $(PNOR_SCRATCH_DIR)/OCCSTRINGFILE.ipllid ;\
             $(TARGET_MAKE_ENV) $(@D)/makelidpkg \
                 $(BINARIES_DIR)/$(XML_VAR).ebmc_lids.tar.gz \
                 $(PNOR_SCRATCH_DIR); \


### PR DESCRIPTION
Adding occStringFile so that a lid file can be created.
Lid: 81e00687

CQ: SW554564
Signed-off-by: Chris Cain <cjcain@us.ibm.com>