### PR TITLE
SBE-P10: Update the call python to python2 for Red Hat 8 migration

### DIFF
--- a/openpower/package/sbe-p10/sbe-p10.mk
+++ b/openpower/package/sbe-p10/sbe-p10.mk
@@ -30,7 +30,7 @@ endef
 
 define SBE_P10_INSTALL_IMAGES_CMDS
 	$(INSTALL) -D $(@D)/images/ipl_image_tool $(HOST_DIR)/usr/bin/
-	python $(@D)/src/build/sbeOpDistribute.py  --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
+	python2 $(@D)/src/build/sbeOpDistribute.py  --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
 	cp $(@D)/src/build/sbeOpDistribute.py $(STAGING_DIR)/sbe_binaries/
 	cp $(@D)/src/build/sbeOpToolsRegister.py $(STAGING_DIR)/sbe_binaries/
 endef


### PR DESCRIPTION
For Red Hat 8, there will be no default /bin/python only /bin/python2
and /bin/python3.  For Red Hat 7 /bin/python is just a symlink to python2,
therefore all calls to python need to be changed to python2 which is
safe to do.

Signed-off-by: Roland Veloz <rveloz@us.ibm.com>