### PR TITLE
Revert "p10 Hcode: Added support for trace parsing in error log."

### DIFF
--- a/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
+++ b/openpower/package/openpower-pnor-p10/openpower-pnor-p10.mk
@@ -3,7 +3,7 @@
 # openpower_pnor_p10
 #
 ################################################################################
-HCODE_STAGE_DIR = $(STAGING_DIR)/../../../build/hcode-p10-*opmst10/output/images_x86_64
+
 OPENPOWER_PNOR_P10_VERSION ?= 38b8d4759092a42d77a4f28939a0e3730f00e1f3
 OPENPOWER_PNOR_P10_SITE ?= $(call github,open-power,pnor,$(OPENPOWER_PNOR_P10_VERSION))
 
@@ -157,9 +157,6 @@ define OPENPOWER_PNOR_P10_UPDATE_IMAGE
             $(INSTALL) -m 0644 -D $(STAGING_DIR)/sbe_sim_data/sbeStringFile_DD1 $(PNOR_SCRATCH_DIR)/SBESTRINGFILE.ipllid && \
             $(INSTALL) -m 0644 -D $(STAGING_DIR)/sbe_sim_data/sbeVerificationStringFile $(PNOR_SCRATCH_DIR)/SBEVSTRINGFILE.ipllid && \
             $(INSTALL) -m 0644 -D $(OCC_STAGING_DIR)/occStringFile $(PNOR_SCRATCH_DIR)/OCCSTRINGFILE.ipllid && \
-            $(INSTALL) -m 0644 -D $(HCODE_STAGE_DIR)/qme_p10dd20/trexStringFile  $(PNOR_SCRATCH_DIR)/QMESTRINGFILE.ipllid && \
-            $(INSTALL) -m 0644 -D $(HCODE_STAGE_DIR)/xgpe_p10dd20/trexStringFile  $(PNOR_SCRATCH_DIR)/XGPESTRINGFILE.ipllid && \
-            $(INSTALL) -m 0644 -D $(HCODE_STAGE_DIR)/pgpe_p10dd20/trexStringFile  $(PNOR_SCRATCH_DIR)/PGPESTRINGFILE.ipllid && \
             $(TARGET_MAKE_ENV) $(@D)/makelidpkg \
                 $(BINARIES_DIR)/$(XML_VAR).ebmc_lids.tar.gz \
                 $(PNOR_SCRATCH_DIR) && \


### PR DESCRIPTION
Reverts open-power/op-build#5263

This change breaks ppc compiles because of the hardcoded "images_x86_64" path.

PNOR UBI image at /tmp/hostboot-jenkins.swg-devops/jenkins-agent/workspace/Hostboot/OpenPower/GHPR/ubuntu-ppc64le-p10-public-github-619/CONFIG/p10ebmc/OS/ubuntu/build/op-build/output/host/powerpc64le-buildroot-linux-gnu/sysroot/pnor.RAINIER_2U_XML/RAINIER_2U_XML.pnor.ubi.mtd
/usr/bin/install: cannot stat '/tmp/hostboot-jenkins.swg-devops/jenkins-agent/workspace/Hostboot/OpenPower/GHPR/ubuntu-ppc64le-p10-public-github-619/CONFIG/p10ebmc/OS/ubuntu/build/op-build/output/host/powerpc64le-buildroot-linux-gnu/sysroot/../../../build/hcode-p10-*opmst10/output/images_x86_64/qme_p10dd20/trexStringFile': No such file or directory


This is what exists in the ppc compile.  I think the generic "images" will probably work.
../../../build/hcode-p10-hw031523a.opmst10/output/images_ppc64le/qme_p10dd20/trexStringFile
../../../build/hcode-p10-hw031523a.opmst10/output/images/qme_p10dd20/trexStringFile
../../../build/hcode-p10-hw031523a.opmst10/output/obj_ppc64le/qme_p10dd20/trexStringFile
../../../build/hcode-p10-hw031523a.opmst10/output/obj/qme_p10dd20/trexStringFile
