### PR TITLE
petitboot: Move to v1.13 release

### DIFF
--- a/openpower/package/petitboot/petitboot.hash
+++ b/openpower/package/petitboot/petitboot.hash
@@ -1,1 +1,1 @@
-sha256 121cab15b1eaaccbe9e054ee1af79d379dc4576379c2c09eb69ccad3ffd7bc5d  petitboot-v1.12.tar.gz
+sha256 b42ae4fb2a81e9cf68f727c3f54c6312788c654bd97628ec9ba61b19a68990e6  petitboot-v1.13.tar.gz

--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PETITBOOT_VERSION = v1.12
+PETITBOOT_VERSION = v1.13
 PETITBOOT_SOURCE = petitboot-$(PETITBOOT_VERSION).tar.gz
 PETITBOOT_SITE ?= https://github.com/open-power/petitboot/releases/download/$(PETITBOOT_VERSION)
 PETITBOOT_DEPENDENCIES = ncurses udev host-bison host-flex lvm2


### PR DESCRIPTION
Changes since v1.12:

  discover/udev.c: Added warning for duplicate FS UUIDs in system status log
  discover/grub2: Add the '-e' test support
  discover: Allow for empty paths
  discover/platform-powerpc: Fix build warning
  ncurses/nc-menu: Remove stray declaration