### PR TITLE
Document bzip2 package requirement; prepare for bzip2 support in buil…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ a handful of other packages (see below).
         sudo add-apt-repository universe
 3. Install the packages necessary for the build:
 
-        sudo apt-get install cscope ctags libz-dev libexpat-dev \
+        sudo apt-get install cscope ctags libz-dev libbz2-dev libexpat-dev \
           python language-pack-en texinfo gawk cpio xxd \
           build-essential g++ git bison flex unzip \
           libssl-dev libxml-simple-perl libxml-sax-perl libxml-parser-perl libxml2-dev libxml2-utils xsltproc \
@@ -70,5 +70,5 @@ a handful of other packages (see below).
           "perl(Env)" "perl(XML::LibXML)" "perl(Digest::SHA1)" "perl(ExtUtils::MakeMaker)" \
           "perl(FindBin)" "perl(English)" "perl(Time::localtime)" \
           libxml2-devel which wget unzip tar cpio python bzip2 bc findutils ncurses-devel \
-          openssl-devel make libxslt vim-common lzo-devel python2 rsync hostname
+          openssl-devel make libxslt vim-common lzo-devel python2 rsync hostname bzip2-devel
 

--- a/openpower/package/sbe-odyssey/Config.in
+++ b/openpower/package/sbe-odyssey/Config.in
@@ -3,6 +3,7 @@ config BR2_PACKAGE_SBE_ODYSSEY
     depends on BR2_PACKAGE_OPENPOWER_PNOR_P10
     select BR2_PACKAGE_HOST_PYTHON3
     select BR2_PACKAGE_HOST_PYTHON3_SSL
+    select BR2_PACKAGE_HOST_PYTHON3_BZIP2
     select BR2_PACKAGE_OP_IMAGE_TOOLS
     help
         Odyssey SBE package.


### PR DESCRIPTION
…droot

The SBE build scripts require the host python interpreter to support bz2. The host-python3 package in our current version of buildroot doesn't correctly add the host-bzip2 dependency when the bzip2 dev option is selected, but it will when we bump our buildroot version. This commit will enable host bzip2 support automatically when that happens.

Until then, this commit documents the bz2 development package requirement for host operatings systems.