### PR TITLE
Revert "buildroot: Bump to version 2023.02-op-build"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "buildroot"]
 	path = buildroot
-	branch = 2023.02-op-build
+	branch = 2021.02-op-build
 	url = https://github.com/open-power/buildroot

--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ a handful of other packages (see below).
 
 ### Dependencies for *64-bit* Ubuntu/Debian systems
 
-1. Install Ubuntu (>= 22.04) or Debian (>= 9) 64-bit.
+1. Install Ubuntu (>= 18.04) or Debian (>= 9) 64-bit.
 2. Enable Universe (Ubuntu only):
 
         sudo apt-get install software-properties-common
         sudo add-apt-repository universe
-
 3. Install the packages necessary for the build:
 
-        sudo apt-get install cscope universal-ctags libz-dev libexpat-dev \
-          python2 python-is-python3 language-pack-en texinfo gawk cpio xxd \
+        sudo apt-get install cscope ctags libz-dev libexpat-dev \
+          python language-pack-en texinfo gawk cpio xxd \
           build-essential g++ git bison flex unzip \
           libssl-dev libxml-simple-perl libxml-sax-perl libxml-parser-perl libxml2-dev libxml2-utils xsltproc \
           wget bc rsync

--- a/openpower/configs/blackbird_defconfig
+++ b/openpower/configs/blackbird_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/blackbird-patches"
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"

--- a/openpower/configs/mihawk_defconfig
+++ b/openpower/configs/mihawk_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/mihawk-patches"
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"

--- a/openpower/configs/mowgli_defconfig
+++ b/openpower/configs/mowgli_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_8_X=y

--- a/openpower/configs/nicole_defconfig
+++ b/openpower/configs/nicole_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_8_X=y

--- a/openpower/configs/opal_defconfig
+++ b/openpower/configs/opal_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"

--- a/openpower/configs/p9dsu_defconfig
+++ b/openpower/configs/p9dsu_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_8_X=y

--- a/openpower/configs/romulus_defconfig
+++ b/openpower/configs/romulus_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_8_X=y

--- a/openpower/configs/swift_defconfig
+++ b/openpower/configs/swift_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_8_X=y

--- a/openpower/configs/witherspoon_defconfig
+++ b/openpower/configs/witherspoon_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_8_X=y

--- a/openpower/configs/zaius_defconfig
+++ b/openpower/configs/zaius_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_8_X=y

--- a/openpower/configs/zz_defconfig
+++ b/openpower/configs/zz_defconfig
@@ -1,4 +1,5 @@
 BR2_powerpc64le=y
+BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"


### PR DESCRIPTION
## What

Reverts open-power/op-build#5629

## Why

It is totally my mistake for not running `git submodule update` which means the `buildroot` is still pointing to the `2021.02-op-build`.

I would like to revert that changes and will work on a [new PR](https://github.com/open-power/op-build/pull/5679) to bump buildroot to `2023.02`.

cc @IlyaSmirnov91 
