### PR TITLE
Adjust Odyssey SBE Build Command

### DIFF
--- a/openpower/package/sbe-odyssey/sbe-odyssey.mk
+++ b/openpower/package/sbe-odyssey/sbe-odyssey.mk
@@ -23,7 +23,7 @@ define SBE_ODYSSEY_BUILD_CMDS
 	echo '. .venv/bin/activate' >> $(@D)/customrc
 	sed -i 's/--user//g' $(@D)/public/src/tools/utils/sbe/sbe-workon-utils
 	$(HOST_DIR)/bin/python3 -m venv $(@D)/.venv --prompt="SBE"
-	cd $(@D) && set -m && ./sbe workon odyssey pnor <<< '. customrc && unset SIGNING_BASE_DIR && ./sbe build && exit' > /dev/null 2>&1
+	cd $(@D) && ./internal/src/test/framework/build-script odyssey pnor --skip-tests > /dev/null 2>&1
 	$(OP_IMAGE_TOOLS_PATH)/imageBuild/imageBuild.py --sbe $(BUILD_DIR)/sbe-odyssey-$(BR2_SBE_ODYSSEY_VERSION)/ --ovrd $(BUILD_DIR)/hostboot-binaries-$(BR2_HOSTBOOT_BINARIES_VERSION)/ -o $(STAGING_DIR)/ody-pak-files --build_workdir $(STAGING_DIR)/ody-pak-files.work $(OP_IMAGE_TOOLS_PATH)/imageBuild/configs/odyssey/dd1/ody_pnor_dd1_image_config
 endef
 


### PR DESCRIPTION
Using the 'sbe workon' command spawns a new shell which can have some bad side effects to some of the automated build scripts. This change switches over to using an inline script for the build instead.