### PR TITLE
Add BR2_OPENPOWER_SIGNED_SECURITY_VERSION into sbe makefiles

### DIFF
--- a/openpower/package/sbe-odyssey/sbe-odyssey.mk
+++ b/openpower/package/sbe-odyssey/sbe-odyssey.mk
@@ -24,7 +24,7 @@ define SBE_ODYSSEY_BUILD_CMDS
 	sed -i 's/--user//g' $(@D)/public/src/tools/utils/sbe/sbe-workon-utils
 	$(HOST_DIR)/bin/python3 -m venv $(@D)/.venv --prompt="SBE"
 	cd $(@D) && ./internal/src/test/framework/build-script odyssey pnor --skip-tests > /dev/null 2>&1
-	$(OP_IMAGE_TOOLS_PATH)/imageBuild/imageBuild.py --sbe $(BUILD_DIR)/sbe-odyssey-$(BR2_SBE_ODYSSEY_VERSION)/ --ovrd $(BUILD_DIR)/hostboot-binaries-$(BR2_HOSTBOOT_BINARIES_VERSION)/ -o $(STAGING_DIR)/ody-pak-files --build_workdir $(STAGING_DIR)/ody-pak-files.work $(OP_IMAGE_TOOLS_PATH)/imageBuild/configs/odyssey/dd1/ody_pnor_dd1_image_config
+	BR2_OPENPOWER_SIGNED_SECURITY_VERSION=${BR2_OPENPOWER_SIGNED_SECURITY_VERSION} $(OP_IMAGE_TOOLS_PATH)/imageBuild/imageBuild.py --sbe $(BUILD_DIR)/sbe-odyssey-$(BR2_SBE_ODYSSEY_VERSION)/ --ovrd $(BUILD_DIR)/hostboot-binaries-$(BR2_HOSTBOOT_BINARIES_VERSION)/ -o $(STAGING_DIR)/ody-pak-files --build_workdir $(STAGING_DIR)/ody-pak-files.work $(OP_IMAGE_TOOLS_PATH)/imageBuild/configs/odyssey/dd1/ody_pnor_dd1_image_config
 endef
 
 define SBE_ODYSSEY_INSTALL_IMAGES_CMDS

--- a/openpower/package/sbe-p10/sbe-p10.mk
+++ b/openpower/package/sbe-p10/sbe-p10.mk
@@ -30,7 +30,8 @@ endef
 
 define SBE_P10_INSTALL_IMAGES_CMDS
 	$(INSTALL) -D $(@D)/images/ipl_image_tool $(HOST_DIR)/usr/bin/
-	python2 $(@D)/src/build/sbeOpDistribute.py  --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
+	BR2_OPENPOWER_SIGNED_SECURITY_VERSION=${BR2_OPENPOWER_SIGNED_SECURITY_VERSION} \
+		python2 $(@D)/src/build/sbeOpDistribute.py --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
 	cp $(@D)/src/build/sbeOpDistribute.py $(STAGING_DIR)/sbe_binaries/
 	cp $(@D)/src/build/sbeOpToolsRegister.py $(STAGING_DIR)/sbe_binaries/
 endef


### PR DESCRIPTION
This commit converts the buildroot variable BR2_OPENPOWER_SIGNED_SECURITY_VERSION into a local environment variable in specific spots of the sbe-p10 and sbe-odyssey makefiles.  This ensures that those packages are built with the same value as the rest of the build.

Resolves #5882