### PR TITLE
Add BR2_OPENPOWER_SIGNED_SECURITY_VERSION into sbe-p10 makefile

### DIFF
--- a/openpower/package/sbe-p10/sbe-p10.mk
+++ b/openpower/package/sbe-p10/sbe-p10.mk
@@ -30,7 +30,8 @@ endef
 
 define SBE_P10_INSTALL_IMAGES_CMDS
 	$(INSTALL) -D $(@D)/images/ipl_image_tool $(HOST_DIR)/usr/bin/
-	python2 $(@D)/src/build/sbeOpDistribute.py  --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
+	BR2_OPENPOWER_SIGNED_SECURITY_VERSION=${BR2_OPENPOWER_SIGNED_SECURITY_VERSION} \
+		python2 $(@D)/src/build/sbeOpDistribute.py  --sbe_binary_dir=$(STAGING_DIR)/sbe_binaries --img_dir=$(@D)/images --sbe_binary_filename $(BINARY_SBE_FILENAME)
 	cp $(@D)/src/build/sbeOpDistribute.py $(STAGING_DIR)/sbe_binaries/
 	cp $(@D)/src/build/sbeOpToolsRegister.py $(STAGING_DIR)/sbe_binaries/
 endef


### PR DESCRIPTION
This commit converts the buildroot variable BR2_OPENPOWER_SIGNED_SECURITY_VERSION into a local environment variable in a specific spot of the sbe-p10 makefile.  This ensures that the sbe-p10 package is built with the same value as the rest of the build.