### PR TITLE
Added consistent salt for HB HPT generation

### DIFF
--- a/openpower/package/openpower-pnor-p11/openpower-pnor-p11.mk
+++ b/openpower/package/openpower-pnor-p11/openpower-pnor-p11.mk
@@ -64,6 +64,9 @@ endif
 
 OPENPOWER_PNOR_P11_OCMB_URL = $(call qstrip,$(OCMB_EXPLORER_FW_SITE)/$(OCMB_EXPLORER_FW_SOURCE))
 
+SALT_FOR_HASH_PAGE_TABLES = $(shell xxd -l 16 -p /dev/urandom)
+export SALT_FOR_HASH_PAGE_TABLES
+
 #######
 # OPENPOWER_PNOR_P11_UPDATE_IMAGE - process/sign PNOR partitions
 # Arguments:


### PR DESCRIPTION
-Sets env var SALT_FOR_HASH_PAGE_TABLES so
 hostboot picks this up and is able to use the
 same value for each pass generating binaries